### PR TITLE
Modifying retry_for_value decorator

### DIFF
--- a/scripts/discovery_tests.py
+++ b/scripts/discovery_tests.py
@@ -111,7 +111,7 @@ class DiscoveryVerification(fixtures.Fixture ):
         self.logger.info("Calculated opserver as per the testbed file..%s"%(publisher_touple)) 
         return publisher_touple
 
-    @retry_for_value(delay=5, tries=50)
+    @retry_for_value(delay=5, tries=5)
     def get_all_control_services(self,ds_ip):
         '''http://10.204.216.7:5998/services.json'''
 
@@ -130,7 +130,7 @@ class DiscoveryVerification(fixtures.Fixture ):
             return lst_ip_service_touple
 
     
-    @retry_for_value(delay=5, tries=50)
+    @retry_for_value(delay=5, tries=5)
     def get_all_collector_services(self,ds_ip):
         '''http://10.204.216.7:5998/services.json'''
 
@@ -149,7 +149,7 @@ class DiscoveryVerification(fixtures.Fixture ):
             self.logger.info("Registered collector services in discovery %s %s"%(ds_ip,lst_ip_service_touple)) 
             return lst_ip_service_touple
 
-    @retry_for_value(delay=5, tries=50)
+    @retry_for_value(delay=5, tries=5)
     def get_all_api_services(self,ds_ip):
         '''http://10.204.216.7:5998/services.json'''
 
@@ -168,7 +168,7 @@ class DiscoveryVerification(fixtures.Fixture ):
             return lst_ip_service_touple
     
 
-    @retry_for_value(delay=5, tries=50)
+    @retry_for_value(delay=5, tries=5)
     def get_all_ifmap_services(self,ds_ip):
         '''http://10.204.216.7:5998/services.json'''
 
@@ -187,7 +187,7 @@ class DiscoveryVerification(fixtures.Fixture ):
             self.logger.info("Registered ifmap services in discovery %s %s"%(ds_ip,lst_ip_service_touple)) 
             return lst_ip_service_touple
 
-    @retry_for_value(delay=5, tries=50)
+    @retry_for_value(delay=5, tries=5)
     def get_all_dns_services(self,ds_ip):
         '''http://10.204.216.7:5998/services.json'''
 
@@ -206,7 +206,7 @@ class DiscoveryVerification(fixtures.Fixture ):
             self.logger.info("Registered dns services in discovery %s %s"%(ds_ip,lst_ip_service_touple)) 
             return lst_ip_service_touple
 
-    @retry_for_value(delay=5, tries=50)
+    @retry_for_value(delay=5, tries=5)
     def get_all_opserver(self,ds_ip):
         '''http://10.204.216.7:5998/services.json'''
 
@@ -225,7 +225,6 @@ class DiscoveryVerification(fixtures.Fixture ):
             self.logger.info("Registered OpServers in discovery %s %s"%(ds_ip,lst_ip_service_touple)) 
             return lst_ip_service_touple
 
-    @retry_for_value(delay=5, tries=50)
     def get_all_services_by_service_name(self,ds_ip,service=None):
         '''http://10.204.216.7:5998/services.json'''
 
@@ -281,7 +280,6 @@ class DiscoveryVerification(fixtures.Fixture ):
         finally:
             return obj
 
-    @retry_for_value(delay=5, tries=50)
     def get_service_status(self,ds_ip ,service_touple=()):
 
         ip=service_touple[0]
@@ -299,7 +297,6 @@ class DiscoveryVerification(fixtures.Fixture ):
         finally:
             return status
 
-    @retry_for_value(delay=5, tries=50)
     def get_service_admin_state(self,ds_ip,service_touple=()):
 
         ip=service_touple[0]
@@ -316,7 +313,6 @@ class DiscoveryVerification(fixtures.Fixture ):
         finally:
             return status
 
-    @retry_for_value(delay=5, tries=50)
     def get_service_id(self,ds_ip ,service_touple=()):
 
         ip=service_touple[0]
@@ -333,7 +329,6 @@ class DiscoveryVerification(fixtures.Fixture ):
         finally:
             return status
 
-    @retry_for_value(delay=5, tries=50)
     def get_service_in_use(self,ds_ip,service_touple=()):
 
         ip=service_touple[0]
@@ -350,7 +345,6 @@ class DiscoveryVerification(fixtures.Fixture ):
         finally:
             return status
 
-    @retry_for_value(delay=5, tries=50)
     def get_service_prov_state(self,ds_ip,service_touple=()):
 
         ip=service_touple[0]
@@ -367,7 +361,6 @@ class DiscoveryVerification(fixtures.Fixture ):
         finally:
             return status
 
-    @retry_for_value(delay=5, tries=50)
     def get_service_endpoint_by_service_id(self,ds_ip ,service_id=None):
 
         t2=()
@@ -382,7 +375,6 @@ class DiscoveryVerification(fixtures.Fixture ):
         finally:
             return t2
 
-    @retry_for_value(delay=5, tries=50)
     def get_service_id_by_service_end_point(self,ds_ip ,service_touple=()):
 
         '''Returns service id of a (service type,ip)'''
@@ -402,7 +394,6 @@ class DiscoveryVerification(fixtures.Fixture ):
             return t2
 
     
-    @retry_for_value(delay=5, tries=50)
     def get_service_status_by_service_id(self,ds_ip ,service_id=None):
 
         t2={}
@@ -426,7 +417,6 @@ class DiscoveryVerification(fixtures.Fixture ):
         finally:
             return t2
     
-    @retry_for_value(delay=5, tries=50)
     def get_hostname_from_hostdata_by_ip(self,hostip):
 
         for elem in self.inputs.host_data.values():
@@ -466,7 +456,7 @@ class DiscoveryVerification(fixtures.Fixture ):
         finally:
             return service_id
 
-    @retry_for_value(delay=5, tries=50)
+    @retry_for_value(delay=5, tries=5)
     def get_xmpp_server_of_agent(self,ds_ip,agent_ip=None):
 
         control_nodes=[]
@@ -480,7 +470,7 @@ class DiscoveryVerification(fixtures.Fixture ):
         finally:
             return control_nodes
     
-    @retry_for_value(delay=5, tries=50)
+    @retry_for_value(delay=5, tries=5)
     def get_all_clients_subscribed_to_a_service(self,ds_ip,service_touple=()):
 
         clients=[]
@@ -501,7 +491,7 @@ class DiscoveryVerification(fixtures.Fixture ):
         finally:
             return clients
 
-    @retry_for_value(delay=5, tries=50)
+    @retry_for_value(delay=5, tries=5)
     def get_all_client_dict_by_service_subscribed_to_a_service(self,ds_ip,subscriber_service,subscribed_service):
 
         ret =[]
@@ -692,7 +682,6 @@ class DiscoveryVerification(fixtures.Fixture ):
 
         return result
     
-    @retry(delay=5, tries=50)
     def verify_bgp_connection(self):
         
         result=True

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -152,7 +152,7 @@ def retry_for_value(tries=5, delay=3):
     '''Retries a function or method until it returns True.
         delay sets the initial delay in seconds. 
     '''
-    tries=tries*1
+    tries=tries*1.0
     tries = math.floor(tries)
     if tries < 0:
         raise ValueError("tries must be 0 or greater")
@@ -162,20 +162,14 @@ def retry_for_value(tries=5, delay=3):
     def deco_retry(f):
         def f_retry(*args, **kwargs):
             mtries, mdelay = tries, delay # make mutable
-
             result = None
-
-            while not result:
+            while (mtries > 0):
                 result = f(*args, **kwargs) # first attempt
                 if result:
                     return result
                 else:
-                    if mtries > 0:
-                        mtries -= 1      # consume an attempt
-                        time.sleep(mdelay) # wait...
-                        result = f(*args, **kwargs) # Try again
-                    else:
-                        return result
+                    mtries -= 1      # consume an attempt
+                    time.sleep(mdelay)
             return result
         return f_retry # true decorator -> decorated function
     return deco_retry  # @retry(arg[, ...]) -> true decorator


### PR DESCRIPTION
In discovery_tests.py,not all get functions needs retry.Nested retry causing test execution to take very long time in case value not received
