### PR TITLE
test_process_restart_with_multiple_vn_vm : Was failing because of the be...

### DIFF
--- a/fixtures/nova_test.py
+++ b/fixtures/nova_test.py
@@ -355,7 +355,7 @@ class NovaFixture(fixtures.Fixture):
                 run('chmod 600 /tmp/id_rsa')
                 self.tmp_key_file='/tmp/id_rsa'
     
-    
+    @threadsafe_generator 
     def get_compute_host(self):
         while True:
             nova_services = self.get_nova_services(binary='nova-compute')

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -8,6 +8,7 @@ import pprint
 from fabric.operations import get, put
 from fabric.api import run
 import logging as log
+import threading
 log.basicConfig(format='%(levelname)s: %(message)s', level=log.DEBUG)
 
 # Code borrowed from http://wiki.python.org/moin/PythonDecoratorLibrary#Retry
@@ -173,4 +174,29 @@ def retry_for_value(tries=5, delay=3):
             return result
         return f_retry # true decorator -> decorated function
     return deco_retry  # @retry(arg[, ...]) -> true decorator
+
 #end retry_for_value
+
+class threadsafe_iterator:
+    """Takes an iterator/generator and makes it thread-safe by
+    serializing call to the `next` method of given iterator/generator.
+    """
+    def __init__(self, it):
+        self.it = it
+        self.lock = threading.Lock()
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        with self.lock:
+            return self.it.next()
+#end threadsafe_iterator
+
+def threadsafe_generator(f):
+    """A decorator that takes a generator function and makes it thread-safe.
+    """
+    def g(*a, **kw):
+        return threadsafe_iterator(f(*a, **kw))
+    return g
+#end thread_safe generator


### PR DESCRIPTION
...low code in nova_test.py

zone= "nova:" + next(self.compute_nodes)
Since,  in the above test case, vms are launched in parallel (using python threading), 2 or more threads probably trying to resume the generator at the same time, hence getting an exception 'ValueError: generator already executing'.
Its a timing issue.

Fixing this using lock on the generator
