### PR TITLE
Unlike neutronclient, HTTPClient for quantum does not accept tenant_id, ...

### DIFF
--- a/fixtures/quantum_test.py
+++ b/fixtures/quantum_test.py
@@ -25,12 +25,13 @@ class NetworkClientException(CommonNetworkClientException):
     
 
 class QuantumFixture(fixtures.Fixture):
-    def __init__(self, username, password, project_id, inputs, cfgm_ip, openstack_ip ):
+    def __init__(self, username, password, project_name, inputs, cfgm_ip, openstack_ip ):
         httpclient=None
         self.quantum_port='9696'
         self.username= username
         self.password= password
-        self.project_id = project_id
+        self.project_id = None
+        self.project_name = project_name
         self.cfgm_ip = cfgm_ip
         self.openstack_ip = openstack_ip
         self.inputs= inputs
@@ -41,12 +42,10 @@ class QuantumFixture(fixtures.Fixture):
 
     def setUp(self):
         super(QuantumFixture, self).setUp()
-        project_id = get_plain_uuid(self.project_id)
         try:
             httpclient = HTTPClient(username= self.username,
-                                tenant_id= project_id,
+                                tenant_name= self.project_name,
                                 password= self.password,
-
                                 auth_url= self.auth_url)
             httpclient.authenticate()
         except CommonNetworkClientException,e:
@@ -55,6 +54,7 @@ class QuantumFixture(fixtures.Fixture):
         OS_URL = 'http://%s:%s/' %(self.cfgm_ip, self.quantum_port)
         OS_TOKEN = httpclient.auth_token
         self.obj = client.Client('2.0', endpoint_url=OS_URL, token = OS_TOKEN)
+        self.project_id = httpclient.auth_tenant_id
     #end setUp
 
     def cleanUp(self):

--- a/scripts/connections.py
+++ b/scripts/connections.py
@@ -58,7 +58,7 @@ class ContrailConnections():
 
         self.quantum_fixture= QuantumFixture(
             username=username, inputs= self.inputs,
-            project_id=self.project_id,
+            project_name=project_name,
             password= password, cfgm_ip= self.inputs.cfgm_ip,
             openstack_ip= self.inputs.openstack_ip)
         self.quantum_fixture.setUp() 


### PR DESCRIPTION
...needs tenant_name
