### PR TITLE
Add a knob in sanity_params to verify_on_setup=True/False so that fixtur...

### DIFF
--- a/fixtures/multiple_vn_vm_test.py
+++ b/fixtures/multiple_vn_vm_test.py
@@ -168,6 +168,28 @@ class create_multiple_vn_and_multiple_vm_fixture(fixtures.Fixture):
         finally:
             return result
 
+    def wait_till_vms_are_up(self):
+        try:
+            result = True
+            verify_threads = []
+            for vm_fix in self.vm_valuelist:
+                t = threading.Thread(target=vm_fix.wait_till_vm_is_up, args=())
+                verify_threads.append(t)
+            for thread in verify_threads:
+                time.sleep(0.5)
+              #  thread.daemon = True
+                thread.start()
+            for thread in verify_threads:
+                thread.join(10)
+            for vm_fix in self.vm_valuelist:
+                if not vm_fix.verify_vm_flag:
+                    result = result and False
+        except Exception as e:
+            print e
+            result = result and False
+        finally:
+            return result
+
     def setUp(self):
 
         super(create_multiple_vn_and_multiple_vm_fixture, self).setUp()

--- a/fixtures/vpc_vm_fixture.py
+++ b/fixtures/vpc_vm_fixture.py
@@ -117,6 +117,9 @@ class VPCVMFixture(fixtures.Fixture):
                          (self.instance_name, self.vm_id))
         return True
     # end verify_on_setup
+    
+    def wait_till_vm_is_up(self):
+        return self.c_vm_fixture.wait_till_vm_is_up()
 
     @retry(delay=10, tries=30)
     def verify_instance(self):

--- a/scripts/analytics_tests_with_setup.py
+++ b/scripts/analytics_tests_with_setup.py
@@ -204,12 +204,15 @@ class AnalyticsTestSanity(testtools.TestCase, ResourcedTestCase, ConfigSvcChain,
 #        self.res.verify_common_objects()
         # start_time=self.analytics_obj.getstarttime(self.tx_vm_node_ip)
         # installing traffic package in vm
-        self.res.vn1_vm1_fixture.verify_on_setup()
-        self.res.vn2_vm2_fixture.verify_on_setup()
-        self.res.fvn_vm1_fixture.verify_on_setup()
-        self.res.vn1_vm1_fixture.install_pkg("Traffic")
-        self.res.vn2_vm2_fixture.install_pkg("Traffic")
-        self.res.fvn_vm1_fixture.install_pkg("Traffic")
+        vn1_vm1_fixture = self.res.get_vn1_vm1_fixture()
+        vn2_vm2_fixture = self.res.get_vn2_vm2_fixture()
+        fvn_vm1_fixture = self.res.get_fvn_vm1_fixture()
+        vn1_vm1_fixture.wait_till_vm_is_up()
+        vn2_vm2_fixture.wait_till_vm_is_up()
+        fvn_vm1_fixture.wait_till_vm_is_up()
+        vn1_vm1_fixture.install_pkg("Traffic")
+        vn2_vm2_fixture.install_pkg("Traffic")
+        fvn_vm1_fixture.install_pkg("Traffic")
 
         self.tx_vm_node_ip = self.inputs.host_data[
             self.nova_fixture.get_nova_host_of_vm(self.res.vn1_vm1_fixture.vm_obj)]['host_ip']
@@ -1055,6 +1058,7 @@ class AnalyticsTestSanity(testtools.TestCase, ResourcedTestCase, ConfigSvcChain,
                                                 vn_obj=vn_obj, vm_name=vm1_name, project_name=self.inputs.project_name))
         # getting vm uuid
         assert vm1_fixture.verify_on_setup()
+        assert vm1_fixture.wait_till_vm_is_up()
         vm_uuid = vm1_fixture.vm_id
         self.logger.info("Waiting for logs to be updated in the database...")
         time.sleep(10)

--- a/scripts/contrail_test_init.py
+++ b/scripts/contrail_test_init.py
@@ -197,6 +197,8 @@ class ContrailTestInit(fixtures.Fixture):
 #        self.fab_revision = config.get('repos', 'fab_revision')
 
         # debug option
+        self.verify_on_setup = self.read_config_option(
+            'debug', 'verify_on_setup', 'True')
         self.stop_on_fail = False
         stop_on_fail = config.get('debug', 'stop_on_fail')
         if stop_on_fail == "yes":

--- a/scripts/ecmp/ecmp_traffic.py
+++ b/scripts/ecmp/ecmp_traffic.py
@@ -22,13 +22,10 @@ class ECMPTraffic(ConfigSvcChain, VerifySvcChain):
         fab_connections.clear()
         vm_list = [src_vm, dst_vm]
         for vm in vm_list:
-            self.logger.info('Getting the local_ip of the VM')
-            vm.verify_vm_in_agent()
-            out = self.nova_fixture.wait_till_vm_is_active(vm.vm_obj)
+            out = vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:
-                time.sleep(5)
                 self.logger.info('Installing Traffic package on %s ...' %
                                  vm.vm_name)
                 vm.install_pkg("Traffic")
@@ -76,7 +73,6 @@ class ECMPTraffic(ConfigSvcChain, VerifySvcChain):
                 stream=stream, listener=dst_vm.vm_ip, chksum=True)
             sender[stream] = Sender(
                 send_filename, profile[stream], tx_local_host, send_host, self.inputs.logger)
-            time.sleep(5)
             receiver[stream] = Receiver(
                 recv_filename, profile[stream], rx_local_host, recv_host, self.inputs.logger)
             receiver[stream].start()

--- a/scripts/ecmp/sanity.py
+++ b/scripts/ecmp/sanity.py
@@ -1026,7 +1026,7 @@ class TestECMP(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtures)
 
         fvm_list = [fvn_vm2, fvn_vm3]
         for vm in fvm_list:
-            out = self.nova_fixture.wait_till_vm_is_up(vm.vm_obj)
+            out = vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:
@@ -1512,16 +1512,15 @@ class TestECMP(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtures)
         assert vm2.verify_on_setup()
         assert fvn_vm1.verify_on_setup()
 
-        out1 = self.nova_fixture.wait_till_vm_is_up(vm1.vm_obj)
+        out1 = vm1.wait_till_vm_is_up()
         if out1 == False:
             return {'result': out1, 'msg': "%s failed to come up" % vm1.vm_name}
         else:
-            sleep(10)
             self.logger.info('Installing Traffic package on %s ...' %
                              vm1.vm_name)
             vm1.install_pkg("Traffic")
 
-        out2 = self.nova_fixture.wait_till_vm_is_up(vm2.vm_obj)
+        out2 = vm2.wait_till_vm_is_up()
         if out2 == False:
             return {'result': out2, 'msg': "%s failed to come up" % vm2.vm_name}
         else:
@@ -1531,7 +1530,7 @@ class TestECMP(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtures)
                              vm2.vm_name)
             vm2.install_pkg("Traffic")
 
-        out3 = self.nova_fixture.wait_till_vm_is_up(fvn_vm1.vm_obj)
+        out3 = fvn_vm1.wait_till_vm_is_up()
         if out3 == False:
             return {'result': out3, 'msg': "%s failed to come up" % fvn_vm1.vm_name}
         else:

--- a/scripts/ecmp/sanity_w_svc.py
+++ b/scripts/ecmp/sanity_w_svc.py
@@ -118,7 +118,7 @@ class ECMPSvcMonSanityFixture(testtools.TestCase, VerifySvcFirewall, ECMPTraffic
         for vm in vm_list:
             self.logger.info('Getting the local_ip of the VM')
             vm.verify_vm_in_agent()
-            out = self.nova_fixture.wait_till_vm_is_up(vm.vm_obj)
+            vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:
@@ -402,7 +402,7 @@ class ECMPSvcMonSanityFixture(testtools.TestCase, VerifySvcFirewall, ECMPTraffic
         for vm in vm_list:
             self.logger.info('Getting the local_ip of the VM')
             vm.verify_vm_in_agent()
-            out = self.nova_fixture.wait_till_vm_is_up(vm.vm_obj)
+            vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:
@@ -574,7 +574,7 @@ class ECMPSvcMonSanityFixture(testtools.TestCase, VerifySvcFirewall, ECMPTraffic
         for vm in vm_list:
             self.logger.info('Getting the local_ip of the VM')
             vm.verify_vm_in_agent()
-            out = self.nova_fixture.wait_till_vm_is_up(vm.vm_obj)
+            vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:
@@ -781,7 +781,7 @@ class ECMPSvcMonSanityFixture(testtools.TestCase, VerifySvcFirewall, ECMPTraffic
         for vm in vm_list:
             self.logger.info('Getting the local_ip of the VM')
             vm.verify_vm_in_agent()
-            out = self.nova_fixture.wait_till_vm_is_up(vm.vm_obj)
+            vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:
@@ -1036,7 +1036,7 @@ class ECMPSvcMonSanityFixture(testtools.TestCase, VerifySvcFirewall, ECMPTraffic
                     connections=self.connections, vn_obj=vn_obj.obj, vm_name=vm_name,
                     project_name=self.inputs.project_name, flavor='contrail_flavor_small', image_name='ubuntu-traffic'))
             assert vm_fix.verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fix.vm_obj)
+            vm_fix.wait_till_vm_is_up()
             vm_list.append(vm_fix)
 
         action_list = []
@@ -1142,7 +1142,7 @@ class ECMPSvcMonSanityFixture(testtools.TestCase, VerifySvcFirewall, ECMPTraffic
         for vm in vm_list:
             self.logger.info('Getting the local_ip of the VM')
             vm.verify_vm_in_agent()
-            out = self.nova_fixture.wait_till_vm_is_up(vm.vm_obj)
+            vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:

--- a/scripts/evpn/verify.py
+++ b/scripts/evpn/verify.py
@@ -201,9 +201,9 @@ class VerifyEvpnCases(TestEncapsulation):
         assert vn_l2_vm3_fixture.verify_on_setup()
 
         # Wait till vm is up
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm2_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm3_fixture.vm_obj)
+        assert vn_l2_vm1_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm2_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm3_fixture.wait_till_vm_is_up()
         # Configured IPV6 address
         cmd_to_pass1 = ['ifconfig eth1 inet6 add %s' % (vn1_vm1)]
         vn_l2_vm1_fixture.run_cmd_on_vm(cmds=cmd_to_pass1, as_sudo=True)
@@ -310,9 +310,9 @@ class VerifyEvpnCases(TestEncapsulation):
         assert vn_l2_vm3_fixture.verify_on_setup()
 
         # Wait till vm is up
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm2_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm3_fixture.vm_obj)
+        assert vn_l2_vm1_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm2_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm3_fixture.wait_till_vm_is_up()
         # Configured IPV6 address
         cmd_to_pass1 = ['ifconfig eth0 inet6 add %s' % (vn1_vm1)]
         vn_l2_vm1_fixture.run_cmd_on_vm(cmds=cmd_to_pass1, as_sudo=True)
@@ -399,8 +399,8 @@ class VerifyEvpnCases(TestEncapsulation):
         assert vn_l2_vm2_fixture.verify_on_setup()
 
         # Wait till vm is up
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm2_fixture.vm_obj)
+        assert vn_l2_vm1_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm2_fixture.wait_till_vm_is_up()
         self.logger.info(
             "Changing vn1 forwarding mode from l2 only to l2l3 followed by calling verify_on_setup for vms which checks if l3 routes are there or not ")
         self.vn1_fixture.add_forwarding_mode(
@@ -483,8 +483,8 @@ class VerifyEvpnCases(TestEncapsulation):
         assert vn_l2_vm2_fixture.verify_on_setup()
 
         # Wait till vm is up
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm2_fixture.vm_obj)
+        assert vn_l2_vm1_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm2_fixture.wait_till_vm_is_up()
         self.logger.info(
             "Changing vn1 forwarding mode from l2l3 to l2 only  followed by calling verify_on_setup for vms which checks l2 routes and explicity check l3 routes are  removed  ")
         self.vn1_fixture.add_forwarding_mode(
@@ -621,8 +621,8 @@ class VerifyEvpnCases(TestEncapsulation):
                              (agent_path_local_vm['routes'][0]['path_list'][0]['vxlan_id']))
 
         # Wait till vm is up
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm2_fixture.vm_obj)
+        assert vn_l2_vm1_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm2_fixture.wait_till_vm_is_up()
 
         # Configure IPV6 address
         cmd_to_pass1 = ['ifconfig eth1 inet6 add %s' % (vm1_ip6)]
@@ -741,8 +741,8 @@ class VerifyEvpnCases(TestEncapsulation):
                              (agent_path_local_vm['routes'][0]['path_list'][0]['vxlan_id']))
 
         # Wait till vm is up
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm2_fixture.vm_obj)
+        assert vn_l2_vm1_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm2_fixture.wait_till_vm_is_up()
 
         # Configure IPV6 address
         cmd_to_pass1 = ['ifconfig eth0 inet6 add %s' % (vm1_ip6)]
@@ -822,9 +822,9 @@ class VerifyEvpnCases(TestEncapsulation):
                                             vn3_fixture.obj, vn4_fixture.obj], image_name='ubuntu', vm_name=vn_l2_vm2_name, node_name=compute_3))
 
         # Wait till vm is up
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm2_fixture.vm_obj)
+        assert vm1_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm1_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm2_fixture.wait_till_vm_is_up()
 
         assert vn3_fixture.verify_on_setup()
         assert vn4_fixture.verify_on_setup()
@@ -961,10 +961,9 @@ class VerifyEvpnCases(TestEncapsulation):
                                             vn3_fixture.obj, vn4_fixture.obj], image_name='ubuntu-traffic', vm_name=vn_l2_vm2_name, node_name=compute_3))
 
         # Wait till vm is up
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm2_fixture.vm_obj)
-        sleep(60)
+        assert vm1_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm1_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm2_fixture.wait_till_vm_is_up()
         assert vn3_fixture.verify_on_setup()
         assert vn4_fixture.verify_on_setup()
         assert vm1_fixture.verify_on_setup()
@@ -1091,8 +1090,8 @@ class VerifyEvpnCases(TestEncapsulation):
         assert vn_l2_vm2_fixture.verify_on_setup()
 
         # Wait till vm is up
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm2_fixture.vm_obj)
+        assert vn_l2_vm1_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm2_fixture.wait_till_vm_is_up()
 
         # Bring the intreface up forcefully
         cmd_to_pass1 = ['ifconfig eth1 1']
@@ -1225,8 +1224,8 @@ class VerifyEvpnCases(TestEncapsulation):
         assert vn_l2_vm2_fixture.verify_on_setup()
 
         # Wait till vm is up
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm2_fixture.vm_obj)
+        assert vn_l2_vm1_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm2_fixture.wait_till_vm_is_up()
 
         # Bring the intreface up forcefully
         cmd_to_pass1 = ['ifconfig eth1 up']
@@ -1512,8 +1511,8 @@ class VerifyEvpnCases(TestEncapsulation):
         assert vn_l2_vm2_fixture.verify_on_setup()
 
         # Wait till vm is up
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm2_fixture.vm_obj)
+        assert vn_l2_vm1_fixture.wait_till_vm_is_up()
+        assert vn_l2_vm2_fixture.wait_till_vm_is_up()
 
         # Configured IPV6 address
         cmd_to_pass1 = ['ifconfig eth1 inet6 add %s' % (vn1_vm1)]
@@ -1668,8 +1667,9 @@ class VerifyEvpnCases(TestEncapsulation):
         assert vn2_fixture.verify_on_setup()
         assert vn1_vm1_fixture.verify_on_setup()
         assert vn1_vm2_fixture.verify_on_setup()
+        assert vn1_vm1_fixture.wait_till_vm_is_up()
+        assert vn1_vm2_fixture.wait_till_vm_is_up()
         for i in range(0, 20):
-            sleep(5)
             vm2_ipv6 = vn1_vm2_fixture.get_vm_ipv6_addr_from_vm()
             if vm2_ipv6 is not None:
                 break
@@ -1687,12 +1687,9 @@ class VerifyEvpnCases(TestEncapsulation):
         sleep(10)
         self.logger.info(
             'Verifying L2 route and other VM verification after restart')
-        assert vn1_vm1_fixture.verify_on_setup()
-        assert vn1_vm2_fixture.verify_on_setup()
-        # vm1_ipv6=vn1_vm1_fixture.get_vm_ipv6_addr_from_vm()
-        # vm2_ipv6=vn1_vm2_fixture.get_vm_ipv6_addr_from_vm()
+        assert vn1_vm1_fixture.verify_on_setup(force=True)
+        assert vn1_vm2_fixture.verify_on_setup(force=True)
         for i in range(0, 20):
-            sleep(5)
             vm2_ipv6 = vn1_vm2_fixture.get_vm_ipv6_addr_from_vm()
             if vm2_ipv6 is not None:
                 break
@@ -1760,8 +1757,8 @@ class VerifyEvpnCases(TestEncapsulation):
         assert vn_l2_vm2_fixture.verify_on_setup()
 
         # Wait till vm is up
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm2_fixture.vm_obj)
+        vn_l2_vm1_fixture.wait_till_vm_is_up()
+        vn_l2_vm2_fixture.wait_till_vm_is_up()
 
         # Configured IPV6 address
         cmd_to_pass1 = ['ifconfig eth1 inet6 add %s' % (vn1_vm1)]

--- a/scripts/floating_ip_tests.py
+++ b/scripts/floating_ip_tests.py
@@ -482,8 +482,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         assert vn1_fixture.verify_on_setup()
         assert fvn1_vm1_traffic_fixture.verify_on_setup()
         assert vn1_vm1_traffic_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(fvn1_vm1_traffic_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_traffic_fixture.vm_obj)
+        fvn1_vm1_traffic_fixture.wait_till_vm_is_up()
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
 
         # Install traffic pkg in VM
         vn1_vm1_traffic_fixture.install_pkg("Traffic")
@@ -661,8 +661,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         if not vn1_vm1_traffic_fixture.ping_with_certainty(fvn1_vm1_traffic_fixture.vm_ip):
             result = result and False
 
-        self.nova_fixture.wait_till_vm_is_up(fvn1_vm1_traffic_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_traffic_fixture.vm_obj)
+        fvn1_vm1_traffic_fixture.wait_till_vm_is_up()
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
         # Install traffic pkg in VM
         vn1_vm1_traffic_fixture.install_pkg("Traffic")
         fvn1_vm1_traffic_fixture.install_pkg("Traffic")
@@ -848,8 +848,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         self.logger.info('Active control node from the Agent %s is %s' %
                          (vn1_vm1_traffic_fixture.vm_node_ip, active_controller))
 
-        self.nova_fixture.wait_till_vm_is_up(fvn1_vm1_traffic_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_traffic_fixture.vm_obj)
+        fvn1_vm1_traffic_fixture.wait_till_vm_is_up()
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
         # Install traffic pkg in VM
         vn1_vm1_traffic_fixture.install_pkg("Traffic")
         fvn1_vm1_traffic_fixture.install_pkg("Traffic")
@@ -1076,8 +1076,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         assert vn1_fixture.verify_on_setup()
         assert fvn1_vm1_fixture.verify_on_setup()
         assert vn1_vm1_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(fvn1_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_fixture.vm_obj)
+        fvn1_vm1_traffic_fixture.wait_till_vm_is_up()
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
 
         fip_fixture1 = self.useFixture(
             FloatingIPFixture(
@@ -1096,7 +1096,7 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         self.logger.info('Rebooting the VM  %s' % (vn1_vm1_name))
         cmd_to_reboot_vm = ['reboot']
         vn1_vm1_fixture.run_cmd_on_vm(cmds=cmd_to_reboot_vm)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_fixture.vm_obj)
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
         assert vn1_vm1_fixture.verify_on_setup()
         self.logger.info('Verify the connectivity to other VN via floating IP')
         if not vn1_vm1_fixture.ping_with_certainty(fvn1_vm1_fixture.vm_ip):
@@ -1128,8 +1128,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         assert vn1_fixture.verify_on_setup()
         assert fvn1_vm1_fixture.verify_on_setup()
         assert vn1_vm1_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(fvn1_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_fixture.vm_obj)
+        fvn1_vm1_traffic_fixture.wait_till_vm_is_up()
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
 
         fip_fixture1 = self.useFixture(
             FloatingIPFixture(
@@ -1522,8 +1522,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
                       vn_obj=vn2_fixture.obj, vm_name=vm_names[1], project_name=projects[1], node_name=compute_2))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
 
         # Floating Ip Fixture
         fip_fixture = self.useFixture(
@@ -1584,8 +1584,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         assert vn1_fixture.verify_on_setup()
         assert fvn1_vm1_traffic_fixture.verify_on_setup()
         assert vn1_vm1_traffic_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(fvn1_vm1_traffic_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_traffic_fixture.vm_obj)
+        fvn1_vm1_traffic_fixture.wait_till_vm_is_up()
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
 
         # Install traffic pkg in VM
         vn1_vm1_traffic_fixture.install_pkg("Traffic")

--- a/scripts/performance/verify.py
+++ b/scripts/performance/verify.py
@@ -84,8 +84,8 @@ class PerformanceTest(ConfigPerformance):
 
             assert self.vm1_fixture.verify_on_setup()
             assert self.vm2_fixture.verify_on_setup()
-            # self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-            # self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+            self.vm1_fixture.wait_till_vm_is_up()
+            self.vm2_fixture.wait_till_vm_is_up()
         else:
             if getattr(self, 'res', None):
                 self.vm1_fixture = self.res.vn1_vm5_fixture
@@ -107,8 +107,8 @@ class PerformanceTest(ConfigPerformance):
 
             assert self.vm1_fixture.verify_on_setup()
             assert self.vm2_fixture.verify_on_setup()
-            # self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-            # self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+            self.vm1_fixture.wait_till_vm_is_up()
+            self.vm2_fixture.wait_till_vm_is_up()
         results = []
         # set the cpu to highest performance in compute nodes before running
         # the test
@@ -224,9 +224,8 @@ class PerformanceTest(ConfigPerformance):
 
             assert self.vm1_fixture.verify_on_setup()
             assert self.vm2_fixture.verify_on_setup()
-            result = self.nova_fixture.wait_till_vm_is_up(
-                self.vm1_fixture.vm_obj)
-            self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+            result = self.vm1_fixture.wait_till_vm_is_up()
+            self.vm2_fixture.wait_till_vm_is_up()
         else:
             if getattr(self, 'res', None):
                 self.vm1_fixture = self.res.vn1_vm5_fixture
@@ -248,8 +247,8 @@ class PerformanceTest(ConfigPerformance):
 
             assert self.vm1_fixture.verify_on_setup()
             assert self.vm2_fixture.verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-            self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+            self.vm1_fixture.wait_till_vm_is_up()
+            self.vm2_fixture.wait_till_vm_is_up()
 
         # set the cpu to highest performance in compute nodes before running
         # the test

--- a/scripts/policyTrafficTests.py
+++ b/scripts/policyTrafficTests.py
@@ -1228,8 +1228,8 @@ class policyTrafficTestFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm2_name, flavor='contrail_flavor_small', image_name='ubuntu-traffic'))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         self.logger.info("Verify ping to vm %s" % (vn1_vm2_name))
         ret = vm1_fixture.ping_with_certainty(
             vm2_fixture.vm_ip, expectation=True)
@@ -1556,8 +1556,8 @@ class policyTrafficTestFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 project_name=self.inputs.project_name, connections=self.connections,
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm2_name))
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         self.logger.info("Verify ping to vm %s" % (vn1_vm2_name))
         ret = vm1_fixture.ping_with_certainty(
             vm2_fixture.vm_ip, expectation=True)

--- a/scripts/securitygroup/sanity_base.py
+++ b/scripts/securitygroup/sanity_base.py
@@ -85,6 +85,7 @@ class SecurityGroupSanityTestsBase(testtools.TestCase, ConfigSecGroup):
             vn_obj=vn.obj, vm_name=vm_name, image_name='ubuntu-traffic', flavor='contrail_flavor_small',
             sg_ids=[secgrp_id]))
         assert vm.verify_on_setup()
+        assert vm.wait_till_vm_is_up()
         result, msg = vm.verify_security_group(secgrp_name)
         assert result, msg
 

--- a/scripts/servicechain/firewall/verify.py
+++ b/scripts/servicechain/firewall/verify.py
@@ -29,8 +29,8 @@ class VerifySvcFirewall(VerifySvcMirror):
         vm2_fixture = self.config_vm(vn2_fixture, vm2_name)
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
 
         si_count = 3
         st_name = "tcp_svc_template"
@@ -237,8 +237,8 @@ class VerifySvcFirewall(VerifySvcMirror):
             self.vm2_fixture = self.config_vm(self.vn2_fixture, self.vm2_name)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -323,8 +323,8 @@ class VerifySvcFirewall(VerifySvcMirror):
             self.vm2_fixture = self.config_vm(self.vn2_fixture, self.vm2_name)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -455,8 +455,8 @@ class VerifySvcFirewall(VerifySvcMirror):
         assert new_left_vm_fix.verify_on_setup()
         assert new_right_vm_fix.verify_on_setup()
         # Wait for VM's to come up
-        self.nova_fixture.wait_till_vm_is_up(new_left_vm_fix.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(new_right_vm_fix.vm_obj)
+        new_left_vm_fix.wait_till_vm_is_up()
+        new_right_vm_fix.wait_till_vm_is_up()
 
         # Add rule to policy to allow traffic from new left_vn to right_vn
         # through SI
@@ -621,8 +621,8 @@ class VerifySvcFirewall(VerifySvcMirror):
         assert new_left_vm_fix.verify_on_setup()
         assert new_right_vm_fix.verify_on_setup()
         # Wait for VM's to come up
-        self.nova_fixture.wait_till_vm_is_up(new_left_vm_fix.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(new_right_vm_fix.vm_obj)
+        new_left_vm_fix.wait_till_vm_is_up()
+        new_right_vm_fix.wait_till_vm_is_up()
 
         # Ping from left VM to right VM
         errmsg = "Ping to right VM ip %s from left VM failed" % new_right_vm_fix.vm_ip
@@ -824,8 +824,8 @@ class VerifySvcFirewall(VerifySvcMirror):
             self.vm2_fixture = self.config_vm(self.vn2_fixture, self.vm2_name)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg

--- a/scripts/servicechain/mirror/verify.py
+++ b/scripts/servicechain/mirror/verify.py
@@ -113,8 +113,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
                 self.vn2_fixture, self.vm2_name, node_name=compute_2)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
         result, msg = self.validate_vn(self.vn2_name)
@@ -260,8 +260,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
                 self.vn2_fixture, self.vm2_name, node_name=compute_2)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -398,8 +398,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
                 self.vn2_fixture, self.vm2_name, node_name=compute_2)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         self.st_fixture, self.si_fixtures = self.config_st_si(self.st_name,
                                                               self.si_prefix, si_count, svc_type='analyzer', left_vn=self.vn1_name)
@@ -570,8 +570,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
         assert new_left_vm_fix.verify_on_setup()
         assert new_right_vm_fix.verify_on_setup()
         # Wait for VM's to come up
-        self.nova_fixture.wait_till_vm_is_up(new_left_vm_fix.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(new_right_vm_fix.vm_obj)
+        new_left_vm_fix.wait_till_vm_is_up()
+        new_right_vm_fix.wait_till_vm_is_up()
 
         # Add rule to policy to allow traffic from new left_vn to right_vn
         # through SI
@@ -778,8 +778,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
                 self.vn2_fixture, self.vm2_name, node_name=compute_2)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -911,8 +911,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
                 self.vn2_fixture, self.vm2_name, node_name=compute_2)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -1053,8 +1053,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -1203,8 +1203,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -1339,8 +1339,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -81,10 +81,8 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
             VMFixture(
                 project_name=self.inputs.project_name, connections=self.connections,
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
-        assert vm1_fixture.verify_on_setup()
-        assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        assert vm1_fixture.wait_till_vm_is_up()
+        assert vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         assert vm2_fixture.ping_to_ip(vm1_fixture.vm_ip)
         return True
@@ -137,10 +135,10 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm2_fixture.verify_on_setup()
         assert vm3_fixture.verify_on_setup()
         assert vm4_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
+        vm3_fixture.wait_till_vm_is_up()
+        vm4_fixture.wait_till_vm_is_up()
         # Geting the VM ips
         vm1_ip = vm1_fixture.vm_ip
         vm2_ip = vm2_fixture.vm_ip
@@ -203,8 +201,8 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         assert vm2_fixture.ping_to_ip(vm1_fixture.vm_ip)
         # Geting the VM ips
@@ -320,8 +318,9 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
+
         assert not vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         return True
 
@@ -386,8 +385,8 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         self.logger.info("Verify ping to vm %s" % (vn1_vm2_name))
         ret = vm1_fixture.ping_with_certainty(
             vm2_fixture.vm_ip, expectation=True)
@@ -417,8 +416,8 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm4_name))
         assert vm3_fixture.verify_on_setup()
         assert vm4_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        vm3_fixture.wait_till_vm_is_up()
+        vm4_fixture.wait_till_vm_is_up()
         self.logger.info("Verify ping to vm %s" % (vn1_vm4_name))
         ret = vm3_fixture.ping_with_certainty(
             vm4_fixture.vm_ip, expectation=True)
@@ -491,8 +490,8 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         return True
 
@@ -529,6 +528,7 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
 
         try:
             assert vm_fixture.verify_vms_on_setup()
+            assert vm_fixture.wait_till_vms_are_up()
             assert vm_fixture.verify_vns_on_setup()
         except Exception as e:
             self.logger.exception("Got exception as %s" % (e))
@@ -541,6 +541,7 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
         sleep(30)
         try:
             assert vm_fixture.verify_vms_on_setup()
+            assert vm_fixture.wait_till_vms_are_up()
 #            for vmobj in vm_fixture.vm_obj_dict.values():
 #                assert vmobj.verify_on_setup()
         except Exception as e:
@@ -586,8 +587,9 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
+
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         assert vm2_fixture.ping_to_ip(vm1_fixture.vm_ip)
 
@@ -687,8 +689,9 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
+
         assert vm2_fixture.ping_to_ip(vm1_fixture.vm_ip)
 
         # Collecting all the control node details
@@ -967,7 +970,8 @@ echo "Hello World.  The time is now $(date -R)!" | tee /tmp/output.txt
                                                 flavor='m1.tiny'))
 
         assert vm1_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        
         cmd = 'ls /tmp/'
 
         for i in range(3):
@@ -1128,7 +1132,7 @@ echo "Hello World.  The time is now $(date -R)!" | tee /tmp/output.txt
                                                 image_name='ubuntu-traffic'))
 
         assert vm1_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
 
         metadata_args = "--admin_user admin \
          --admin_password contrail123 --linklocal_service_name generic_link_local\

--- a/scripts/tests_with_setup_base.py
+++ b/scripts/tests_with_setup_base.py
@@ -93,6 +93,7 @@ class TestSanityBase(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFix
         vm1_fixture = self.useFixture(VMFixture(connections=self.connections,
                                                 vn_obj=vn_obj, vm_name=vm1_name, project_name=self.inputs.project_name, image_name='ubuntu'))
         assert vm1_fixture.verify_on_setup()
+        assert vm1_fixture.wait_till_vm_is_up()
         return True
     # end test_vm_add_delete
 
@@ -108,10 +109,13 @@ class TestSanityBase(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFix
         result = True
         fip_pool_name = 'some-pool1'
         fvn_name = self.res.fip_vn_name
-        fvn_fixture = self.res.fvn_fixture
-        vn1_fixture = self.res.vn1_fixture
-        vn1_vm1_fixture = self.res.vn1_vm1_fixture
-        fvn_vm1_fixture = self.res.fvn_vm1_fixture
+        fvn_fixture = self.res.get_fvn_fixture()
+        vn1_fixture = self.res.get_vn1_fixture()
+        vn1_vm1_fixture = self.res.get_vn1_vm1_fixture()
+        assert vn1_vm1_fixture.verify_on_setup(force=True)
+        assert vn1_vm1_fixture.wait_till_vm_is_up()
+        fvn_vm1_fixture = self.res.get_fvn_vm1_fixture()
+        assert fvn_vm1_fixture.wait_till_vm_is_up()
         fvn_subnets = self.res.fip_vn_subnets
         vm1_name = self.res.vn1_vm1_name
         vn1_name = self.res.vn1_name

--- a/scripts/topo_steps.py
+++ b/scripts/topo_steps.py
@@ -424,7 +424,7 @@ def createVMNova(self, option='openstack', vms_on_single_compute=False, VmToNode
             # if launching more VMs...
             retry = 0
             while True:
-                vm_verify_out = self.vm_fixture[vm].verify_on_setup()
+                vm_verify_out = self.vm_fixture[vm].wait_till_vm_is_up()
                 retry += 1
                 if vm_verify_out == True or retry > 2:
                     break

--- a/scripts/vdns/vdns_tests.py
+++ b/scripts/vdns/vdns_tests.py
@@ -125,7 +125,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 VMFixture(project_name=self.inputs.project_name, connections=self.connections, vn_obj=vn_quantum_obj, vm_name=vm_name))
             vm_fixture[vm_name].verify_vm_launched()
             vm_fixture[vm_name].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[vm_name].vm_obj)
+            vm_fixture[vm_name].wait_till_vm_is_up()
             vm_ip = vm_fixture[vm_name].get_vm_ip_from_vm(
                 vn_fq_name=vm_fixture[vm_name].vn_fq_name)
             vm_rev_ip = vm_ip.split('.')
@@ -238,7 +238,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 VMFixture(project_name=self.inputs.project_name, connections=self.connections, vn_obj=vn_quantum_obj, vm_name=vm_name))
             vm_fixture[vm_name].verify_vm_launched()
             vm_fixture[vm_name].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[vm_name].vm_obj)
+            vm_fixture[vm_name].wait_till_vm_is_up()
             msg = "Ping by using name %s is failed. Dns server should resolve VM name to IP" % (
                 vm_name)
             self.assertTrue(vm_fixture[vm_name]
@@ -450,7 +450,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 VMFixture(project_name=self.inputs.project_name, connections=self.connections, vn_obj=vn_quantum_obj, vm_name=vm_name))
             vm_fixture[vm_name].verify_vm_launched()
             vm_fixture[vm_name].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[vm_name].vm_obj)
+            vm_fixture[vm_name].wait_till_vm_is_up()
 
         # Verify DNS entries are resolved for sub domains.
         for vm_name in vm_list:
@@ -568,7 +568,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 VMFixture(project_name=self.inputs.project_name, connections=self.connections, vn_obj=vn_quantum_obj, vm_name=vm_name))
             vm_fixture[vm_name].verify_vm_launched()
             vm_fixture[vm_name].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[vm_name].vm_obj)
+            vm_fixture[vm_name].wait_till_vm_is_up()
             vm_ip = vm_fixture[vm_name].get_vm_ip_from_vm(
                 vn_fq_name=vm_fixture[vm_name].vn_fq_name)
             vm_rev_ip = vm_ip.split('.')
@@ -743,7 +743,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                       connections=self.connections, vn_obj=vn_quantum_obj, vm_name='vm1-test'))
         vm_fixture.verify_vm_launched()
         vm_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm_fixture.vm_obj)
+        vm_fixture.wait_till_vm_is_up()
 
         rec_ip_list = []
         i = 1
@@ -912,7 +912,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 VMFixture(project_name=self.inputs.project_name, connections=self.connections, vn_obj=vn_fixt[vm_name].obj, vm_name=vm_name))
             vm_fixture[vm_name].verify_vm_launched()
             vm_fixture[vm_name].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[vm_name].vm_obj)
+            vm_fixture[vm_name].wait_till_vm_is_up()
 
         # FIP
         fip_fixture1 = self.useFixture(
@@ -1005,7 +1005,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                     vm_name=vm_list[proj]))
             vm_fix[proj].verify_vm_launched()
             vm_fix[proj].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fix[proj].vm_obj)
+            vm_fixture[vm_name].wait_till_vm_is_up()
             msg = "Ping by using name %s is failed. Dns server should resolve VM name to IP" % (
                 vm_list[proj])
             self.assertTrue(
@@ -1070,7 +1070,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 vm_name=vm_name))
         vm_fix.verify_vm_launched()
         vm_fix.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm_fix.vm_obj)
+        vm_fix.wait_till_vm_is_up()
         # FIP creation
         fip_fixture = self.useFixture(
             FloatingIPFixture(
@@ -1244,7 +1244,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 project_name=self.inputs.project_name, connections=self.connections, vn_obj=vn_fixt[dns_name].obj, vm_name=vm_dns_list[dns_name]))
             vm_fixture[dns_name].verify_vm_launched()
             vm_fixture[dns_name].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[dns_name].vm_obj)
+            vm_fixture[dns_name].wait_till_vm_is_up()
             vm_ip_dns_list[dns_name] = vm_fixture[dns_name].vm_ip
         # perform NS lookup for each level
         import re
@@ -1348,7 +1348,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                     vn_obj=vn_fixt.obj, vm_name=vm_name))
             vm_fixture[vdns].verify_vm_launched()
             vm_fixture[vdns].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[vdns].vm_obj)
+            vm_fixture[vdns].wait_till_vm_is_up()
             # get vm IP from nova
             vm_ip = vm_fixture[vdns].vm_ip
             i = i + 1

--- a/scripts/vm_vn_tests.py
+++ b/scripts/vm_vn_tests.py
@@ -181,8 +181,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
 
         return True
@@ -211,8 +211,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         self.logger.info('Will restart the services now')
         for compute_ip in self.inputs.compute_ips:
@@ -277,8 +277,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
 
         try:
@@ -362,8 +362,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                                                 vn_obj=vn_obj, vm_name=vm2_name, project_name=self.inputs.project_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
 
         self.logger.info(
@@ -398,7 +398,7 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         vm1_fixture = self.useFixture(VMFixture(connections=self.connections,
                                                 vn_obj=vn_obj, vm_name=vm1_name, project_name=self.inputs.project_name))
         assert vm1_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
 
         self.logger.info('Adding the same address as a Static IP')
         cmd = 'ifconfig eth0 %s netmask 255.255.255.0' % vm1_fixture.vm_ip
@@ -467,15 +467,17 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vn_fixture.verify_on_setup()
         vn_obj = vn_fixture.obj
         vm1_fixture = self.useFixture(VMFixture(connections=self.connections,
-                                                vn_obj=vn_obj, flavor='contrail_flavor_small', image_name='ubuntu-traffic', vm_name=vm1_name, project_name=self.inputs.project_name))
-        assert vm1_fixture.verify_on_setup()
+                            vn_obj=vn_obj, flavor='contrail_flavor_small', 
+                            image_name='ubuntu-traffic', vm_name=vm1_name, 
+                            project_name=self.inputs.project_name))
         vm2_fixture = self.useFixture(VMFixture(connections=self.connections,
-                                                vn_obj=vn_obj, flavor='contrail_flavor_small', image_name='ubuntu-traffic', vm_name=vm2_name, project_name=self.inputs.project_name))
-        assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+                            vn_obj=vn_obj, flavor='contrail_flavor_small', 
+                            image_name='ubuntu-traffic', vm_name=vm2_name, 
+                            project_name=self.inputs.project_name))
+        assert vm1_fixture.wait_till_vm_is_up()
+        assert vm2_fixture.wait_till_vm_is_up()
+
         # ssh and tftp taking sometime to be up and runnning
-        sleep(60)
         for size in file_sizes:
             self.logger.info("-" * 80)
             self.logger.info("FILE SIZE = %sB" % size)
@@ -498,7 +500,11 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                 self.logger.error(
                     'File of size %sB not transferred via tftp ' % size)
 
-        assert transfer_result, 'File not transferred via tftp '
+        if not transfer_result:
+            self.logger.error('Tftp transfer failed, lets verify basic things')
+            assert vm1_fixture.verify_on_setup()
+            assert vm2_fixture.verify_on_setup()
+            assert transfer_result
         return transfer_result
     # end test_vm_file_trf_tftp_tests
 
@@ -678,7 +684,7 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         vm1_fixture = self.useFixture(VMFixture(connections=self.connections,
                                                 vn_obj=vn_obj, vm_name=vm1_name, project_name=self.inputs.project_name, flavor='contrail_flavor_small', image_name='ubuntu-traffic'))
         assert vm1_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
         route_cmd = 'route -n'
         vm1_fixture.run_cmd_on_vm(cmds=[route_cmd], as_sudo=True)
         output = vm1_fixture.return_output_cmd_dict[route_cmd]
@@ -698,7 +704,7 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         vm2_fixture = self.useFixture(VMFixture(connections=self.connections,
                                                 vn_obj=vn_obj, vm_name=vm2_name, project_name=self.inputs.project_name, flavor='contrail_flavor_small', image_name='ubuntu-traffic'))
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm2_fixture.wait_till_vm_is_up()
         new_route_cmd = 'route -n'
         vm2_fixture.run_cmd_on_vm(cmds=[new_route_cmd], as_sudo=True)
         new_output = vm2_fixture.return_output_cmd_dict[new_route_cmd]
@@ -869,15 +875,11 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
 
         vm5_fixture = self.useFixture(VMFixture(connections=self.connections,
                                                 vn_obj=vn_obj, vm_name='vm_xlarge', flavor='m1.xlarge', project_name=self.inputs.project_name))
-        assert vm1_fixture.verify_on_setup()
-        assert vm2_fixture.verify_on_setup()
-        assert vm3_fixture.verify_on_setup()
-        assert vm4_fixture.verify_on_setup()
-        assert vm5_fixture.verify_on_setup()
 
         for a in range(1, 6):
-            eval('self.nova_fixture.wait_till_vm_is_up(vm%d_fixture.vm_obj )' %
+            wait = eval('vm%d_fixture.wait_till_vm_is_up()' %
                  a)
+            assert 'wait'
 
         for i in range(1, 5):
             for j in range(i + 1, 6):
@@ -1004,7 +1006,7 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
             'vm2 has not booted up as expected.Starting vrouter service')
         for compute_ip in self.inputs.compute_ips:
             self.inputs.start_service('contrail-vrouter', [compute_ip])
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm2_fixture.wait_till_vm_is_up()
         self.logger.info('vm2 is up now as expected')
         assert vm2_fixture.verify_on_setup()
 
@@ -1183,20 +1185,18 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
             assert vm1_fixture.verify_on_setup()
             assert vm2_fixture.verify_on_setup()
 
-        out1 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out1 = vm1_fixture.wait_till_vm_is_up()
         if out1 == False:
             return {'result': out1, 'msg': "%s failed to come up" % vm1_fixture.vm_name}
         else:
-            sleep(10)
             self.logger.info('Will install Traffic package on %s' %
                              vm1_fixture.vm_name)
             vm1_fixture.install_pkg("Traffic")
 
-        out2 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out2 = vm2_fixture.wait_till_vm_is_up()
         if out2 == False:
             return {'result': out2, 'msg': "%s failed to come up" % vm2_fixture.vm_name}
         else:
-            sleep(10)
             self.logger.info('Will install Traffic package on %s' %
                              vm2_fixture.vm_name)
             vm2_fixture.install_pkg("Traffic")
@@ -1308,20 +1308,18 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
             assert vm1_fixture.verify_on_setup()
             assert vm2_fixture.verify_on_setup()
 
-        out1 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out1 = vm1_fixture.wait_till_vm_is_up()
         if out1 == False:
             return {'result': out1, 'msg': "%s failed to come up" % vm1_fixture.vm_name}
         else:
-            sleep(10)
             self.logger.info('Will install Traffic package on %s' %
                              vm1_fixture.vm_name)
             vm1_fixture.install_pkg("Traffic")
 
-        out2 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out2 = vm2_fixture.wait_till_vm_is_up()
         if out2 == False:
             return {'result': out2, 'msg': "%s failed to come up" % vm2_fixture.vm_name}
         else:
-            sleep(10)
             self.logger.info('Will install Traffic package on %s' %
                              vm2_fixture.vm_name)
             vm2_fixture.install_pkg("Traffic")
@@ -1446,7 +1444,7 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
             assert vm1_fixture.verify_on_setup()
             assert vm2_fixture.verify_on_setup()
 
-        out1 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out1 = vm1_fixture.wait_till_vm_is_up()
         if out1 == False:
             return {'result': out1, 'msg': "%s failed to come up" % vm1_fixture.vm_name}
         else:
@@ -1455,7 +1453,7 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                              vm1_fixture.vm_name)
             vm1_fixture.install_pkg("Traffic")
 
-        out2 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out2 = vm2_fixture.wait_till_vm_is_up()
         if out2 == False:
             return {'result': out2, 'msg': "%s failed to come up" % vm2_fixture.vm_name}
         else:
@@ -1623,8 +1621,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
 
         self.logger.info(
@@ -1661,8 +1659,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm3_fixture.verify_on_setup()
         assert vm4_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        vm3_fixture.wait_till_vm_is_up()
+        vm4_fixture.wait_till_vm_is_up()
         assert not vm4_fixture.ping_to_ip(vm3_fixture.vm_ip)
         return True
     # end test_policy_between_vns_diff_proj
@@ -2033,19 +2031,16 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, flavor='contrail_flavor_small', image_name='ubuntu-traffic', vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
 
-        out1 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out1 = vm1_fixture.wait_till_vm_is_up()
         if out1 == False:
             return {'result': out1, 'msg': "%s failed to come up" % vm1_fixture.vm_name}
         else:
-            sleep(10)
             self.logger.info('Will install Traffic package on %s' %
                              vm1_fixture.vm_name)
             vm1_fixture.install_pkg("Traffic")
 
-        out2 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out2 = vm2_fixture.wait_till_vm_is_up()
         if out2 == False:
             return {'result': out2, 'msg': "%s failed to come up" % vm2_fixture.vm_name}
         else:
@@ -2116,8 +2111,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         assert vm2_fixture.ping_to_ip(vm1_fixture.vm_ip)
         return True
@@ -2160,10 +2155,11 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm2_fixture.verify_on_setup()
         assert vm3_fixture.verify_on_setup()
         assert vm4_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
+        vm3_fixture.wait_till_vm_is_up()
+        vm4_fixture.wait_till_vm_is_up()
+
         # Geting the VM ips
         vm1_ip = vm1_fixture.vm_ip
         vm2_ip = vm2_fixture.vm_ip
@@ -2258,42 +2254,34 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         #self.nova_fixture.wait_till_vm_is_up( vm3_fixture.vm_obj )
         #self.nova_fixture.wait_till_vm_is_up( vm4_fixture.vm_obj )
 
-        out1 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out1 = vm1_fixture.wait_till_vm_is_up()
         if out1 == False:
             return {'result': out1, 'msg': "%s failed to come up" % vm1_fixture.vm_name}
         else:
-            sleep(
-                10)
             self.logger.info('Installing Traffic package on %s ...' %
                              vm1_fixture.vm_name)
             vm1_fixture.install_pkg("Traffic")
 
-        out2 = self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        out2 = vm2_fixture.wait_till_vm_is_up()
         if out2 == False:
             return {'result': out2, 'msg': "%s failed to come up" % vm2_fixture.vm_name}
         else:
-            sleep(
-                10)
             self.logger.info('Installing Traffic package on %s ...' %
                              vm2_fixture.vm_name)
             vm2_fixture.install_pkg("Traffic")
 
-        out3 = self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
+        out3 = vm3_fixture.wait_till_vm_is_up()
         if out3 == False:
             return {'result': out3, 'msg': "%s failed to come up" % vm3_fixture.vm_name}
         else:
-            sleep(
-                10)
             self.logger.info('Installing Traffic package on %s ...' %
                              vm3_fixture.vm_name)
             vm3_fixture.install_pkg("Traffic")
 
-        out4 = self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        out4 = vm4_fixture.wait_till_vm_is_up()
         if out4 == False:
             return {'result': out4, 'msg': "%s failed to come up" % vm4_fixture.vm_name}
         else:
-            sleep(
-                10)
             self.logger.info('Installing Traffic package on %s ...' %
                              vm4_fixture.vm_name)
             vm4_fixture.install_pkg("Traffic")
@@ -2424,10 +2412,10 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm2_fixture.verify_on_setup()
         assert vm3_fixture.verify_on_setup()
         assert vm4_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
+        vm3_fixture.wait_till_vm_is_up()
+        vm4_fixture.wait_till_vm_is_up()
         # Geting the VM ips
         vm1_ip = vm1_fixture.vm_ip
         vm2_ip = vm2_fixture.vm_ip
@@ -2487,8 +2475,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         assert vm2_fixture.ping_to_ip(vm1_fixture.vm_ip)
         # Geting the VM ips
@@ -2583,8 +2571,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         self.logger.info("Verify ping to vm %s" % (vn1_vm2_name))
         ret = vm1_fixture.ping_with_certainty(
             vm2_fixture.vm_ip, expectation=True)
@@ -2614,8 +2602,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm4_name))
         assert vm3_fixture.verify_on_setup()
         assert vm4_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        vm3_fixture.wait_till_vm_is_up()
+        vm4_fixture.wait_till_vm_is_up()
         self.logger.info("Verify ping to vm %s" % (vn1_vm4_name))
         ret = vm3_fixture.ping_with_certainty(
             vm4_fixture.vm_ip, expectation=True)

--- a/scripts/vpc/sanity.py
+++ b/scripts/vpc/sanity.py
@@ -365,10 +365,14 @@ class VPCSanityTests(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFix
             vm_name='fip_vm1'))
         assert fip_vm_fixture.verify_on_setup(
         ), "VM verification in FIP VN failed"
+        assert fip_vm_fixture.wait_till_vm_is_up(),\
+            "VM verification in FIP VN failed"
 
         vm1_fixture = self.res.vpc1_vn1_vm1_fixture
         assert vm1_fixture.verify_on_setup(), "VPCVMFixture verification failed " \
             "for VM %s" % (vm1_fixture.instance_id)
+        assert vm1_fixture.wait_till_vm_is_up(),\
+            "VM verification failed"
 
         fip_fixture = self.useFixture(VPCFIPFixture(
             fip_vn_fixture=fip_vn_fixture,


### PR DESCRIPTION
...e based verify_on_setup() calls can be skipped altogether. Caller can still force a verify based on argument. Modified Sanity tests to use vmfixture.wait_till_vm_is_up
