### PR TITLE
Add a knob in sanity_params to verify_on_setup=True/False so that fixtur...

### DIFF
--- a/fixtures/multiple_vn_vm_test.py
+++ b/fixtures/multiple_vn_vm_test.py
@@ -168,6 +168,28 @@ class create_multiple_vn_and_multiple_vm_fixture(fixtures.Fixture):
         finally:
             return result
 
+    def wait_till_vms_are_up(self):
+        try:
+            result = True
+            verify_threads = []
+            for vm_fix in self.vm_valuelist:
+                t = threading.Thread(target=vm_fix.wait_till_vm_is_up, args=())
+                verify_threads.append(t)
+            for thread in verify_threads:
+                time.sleep(0.5)
+              #  thread.daemon = True
+                thread.start()
+            for thread in verify_threads:
+                thread.join(10)
+            for vm_fix in self.vm_valuelist:
+                if not vm_fix.verify_vm_flag:
+                    result = result and False
+        except Exception as e:
+            print e
+            result = result and False
+        finally:
+            return result
+
     def setUp(self):
 
         super(create_multiple_vn_and_multiple_vm_fixture, self).setUp()

--- a/fixtures/vm_test.py
+++ b/fixtures/vm_test.py
@@ -209,7 +209,10 @@ class VMFixture(fixtures.Fixture):
         self.logger.warn(errmsg)
         return False, errmsg
 
-    def verify_on_setup(self):
+    def verify_on_setup(self, force=False):
+        if self.inputs.verify_on_setup == 'False' and not force:
+            self.logger.info('Skipping VM %s verification' % (self.vm_name))
+            return True
         result = True
         self.verify_vm_flag = True
         t_launch = threading.Thread(target=self.verify_vm_launched, args=())
@@ -1489,7 +1492,51 @@ class VMFixture(fixtures.Fixture):
     # end def
 
     def wait_till_vm_is_up(self):
-        return self.nova_fixture.wait_till_vm_is_up(self.vm_obj)
+        result = self.verify_vm_launched()
+        #console_check = self.nova_fixture.wait_till_vm_is_up(self.vm_obj)
+        #result = result and self.nova_fixture.wait_till_vm_is_up(self.vm_obj)
+        #if not console_check : 
+        #    import pdb; pdb.set_trace()
+        #    self.logger.warn('Console logs didnt give enough info on bootup')
+        self.vm_obj.get()
+        result = result and self._gather_details()
+        result = result and self.wait_for_ssh_on_vm()
+        if not result : 
+            self.logger.error('Failed to SSH to VM %s' % (self.vm_name))
+            return result
+        return True
+    # end wait_till_vm_is_up
+    
+    def wait_for_ssh_on_vm(self):
+        self.logger.info('Waiting to SSH to VM %s, IP %s' % (self.vm_name, 
+                           self.vm_ip))
+        
+        # Need fab files on compute node before talking to VMs
+        host = self.inputs.host_data[self.vm_node_ip]
+        with settings(host_string='%s@%s' % (host['username'],
+                      self.vm_node_ip), password=host['password'],
+                      warn_only=True, abort_on_prompts=False):
+            put('tcutils/fabfile.py', '~/')
+
+        # Check if ssh from compute node to VM works(with retries)
+        cmd = 'fab -u %s -p %s -H %s -D -w --hide status,user,running wait_for_ssh:' % (self.vm_username, self.vm_password, self.local_ip)
+        output = self.inputs.run_cmd_on_server(self.vm_node_ip, cmd,
+                            self.inputs.host_data[
+                            self.vm_node_ip]['username'],
+                            self.inputs.host_data[self.vm_node_ip]['password'])
+        output = remove_unwanted_output(output)
+
+        if 'True' in output :
+            self.logger.info('VM %s is ready for SSH connections ' % (
+                           self.vm_name))
+            return True
+        else:
+            self.logger.error('VM %s is NOT ready for SSH connections ' % (
+                           self.vm_name))
+            return False
+    # end wait_for_ssh_on_vm    
+    
+>>>>>>> e9d4326... Add a knob in sanity_params to verify_on_setup=True/False so that fixture based verify_on_setup() calls can be skipped altogether. Caller can still force a verify based on argument. Modified Sanity tests to use vmfixture.wait_till_vm_is_up
 
     def get_vm_ipv6_addr_from_vm(self, intf='eth0', addr_type='link'):
         ''' Get VM IPV6 from Ifconfig output executed on VM
@@ -1554,6 +1601,51 @@ class VMFixture(fixtures.Fixture):
         self.vm_flows_removed_flag = self.vm_flows_removed_flag and result
         return result
     # end verify_vm_flows_removed
+
+    @retry(delay=3, tries=30)
+    def _gather_details(self):
+        self.cs_vmi_objs = {}
+        self.cs_vmi_obj = {}
+        self.vm_id = self.vm_objs[0].id
+        # Figure out the local metadata IP of the VM reachable from host
+        nova_host = self.inputs.host_data[
+            self.nova_fixture.get_nova_host_of_vm(self.vm_obj)]
+        self.vm_node_ip = nova_host['host_ip']
+        self.vm_node_data_ip = nova_host['host_data_ip']
+        inspect_h= self.agent_inspect[self.vm_node_ip]
+
+        cfgm_ip = self.inputs.cfgm_ips[0]
+        api_inspect = self.api_s_inspects[cfgm_ip]
+        self.cs_vmi_objs[cfgm_ip]= api_inspect.get_cs_vmi_of_vm( self.vm_id)
+        for vmi_obj in self.cs_vmi_objs[cfgm_ip]:
+            vmi_vn_fq_name= ':'.join(
+            vmi_obj['virtual-machine-interface']['virtual_network_refs'][0]['to'])
+            self.cs_vmi_obj[vmi_vn_fq_name] = vmi_obj
+
+        for vn_fq_name in self.vn_fq_names:
+            (domain, project, vn)= vn_fq_name.split(':')
+            vna_tap_id = inspect_h.get_vna_tap_interface_by_vmi( 
+                vmi_id=self.cs_vmi_obj[vn_fq_name][ 
+                    'virtual-machine-interface' ]['uuid'])
+            self.tap_intf[vn_fq_name] = vna_tap_id[0]
+            self.tap_intf[vn_fq_name]= inspect_h.get_vna_intf_details(
+                self.tap_intf[vn_fq_name][ 'name' ])[0]
+            self.local_ips[vn_fq_name] = self.tap_intf[vn_fq_name]['mdata_ip_addr']
+            if self.local_ips[vn_fq_name] != '0.0.0.0':
+                if self.ping_vm_from_host(vn_fq_name) or self.ping_vm_from_host( vn_fq_name) :
+                    self.local_ip= self.local_ips[vn_fq_name]
+        if not self.local_ip:
+            return False
+        return True
+    # end _gather_details 
+ 
+    def interface_attach(self, port_id=None, net_id=None, fixed_ip=None):
+        self.logger.info('Attaching port %s to VM %s' %(port_id, self.vm_obj.name))
+        return self.vm_obj.interface_attach(port_id, net_id, fixed_ip)
+
+    def interface_detach(self, port_id):
+        self.logger.info('Detaching port %s from VM %s' %(port_id, self.vm_obj.name))
+        return self.vm_obj.interface_detach(port_id)
 
 # end VMFixture
 

--- a/fixtures/vpc_vm_fixture.py
+++ b/fixtures/vpc_vm_fixture.py
@@ -117,6 +117,9 @@ class VPCVMFixture(fixtures.Fixture):
                          (self.instance_name, self.vm_id))
         return True
     # end verify_on_setup
+    
+    def wait_till_vm_is_up(self):
+        return self.c_vm_fixture.wait_till_vm_is_up()
 
     @retry(delay=10, tries=30)
     def verify_instance(self):

--- a/scripts/analytics_tests_with_setup.py
+++ b/scripts/analytics_tests_with_setup.py
@@ -204,12 +204,15 @@ class AnalyticsTestSanity(testtools.TestCase, ResourcedTestCase, ConfigSvcChain,
 #        self.res.verify_common_objects()
         # start_time=self.analytics_obj.getstarttime(self.tx_vm_node_ip)
         # installing traffic package in vm
-        self.res.vn1_vm1_fixture.verify_on_setup()
-        self.res.vn2_vm2_fixture.verify_on_setup()
-        self.res.fvn_vm1_fixture.verify_on_setup()
-        self.res.vn1_vm1_fixture.install_pkg("Traffic")
-        self.res.vn2_vm2_fixture.install_pkg("Traffic")
-        self.res.fvn_vm1_fixture.install_pkg("Traffic")
+        vn1_vm1_fixture = self.res.get_vn1_vm1_fixture()
+        vn2_vm2_fixture = self.res.get_vn2_vm2_fixture()
+        fvn_vm1_fixture = self.res.get_fvn_vm1_fixture()
+        vn1_vm1_fixture.wait_till_vm_is_up()
+        vn2_vm2_fixture.wait_till_vm_is_up()
+        fvn_vm1_fixture.wait_till_vm_is_up()
+        vn1_vm1_fixture.install_pkg("Traffic")
+        vn2_vm2_fixture.install_pkg("Traffic")
+        fvn_vm1_fixture.install_pkg("Traffic")
 
         self.tx_vm_node_ip = self.inputs.host_data[
             self.nova_fixture.get_nova_host_of_vm(self.res.vn1_vm1_fixture.vm_obj)]['host_ip']
@@ -1057,6 +1060,7 @@ class AnalyticsTestSanity(testtools.TestCase, ResourcedTestCase, ConfigSvcChain,
                                                 vn_obj=vn_obj, vm_name=vm1_name, project_name=self.inputs.project_name))
         # getting vm uuid
         assert vm1_fixture.verify_on_setup()
+        assert vm1_fixture.wait_till_vm_is_up()
         vm_uuid = vm1_fixture.vm_id
         self.logger.info("Waiting for logs to be updated in the database...")
         time.sleep(10)

--- a/scripts/contrail_test_init.py
+++ b/scripts/contrail_test_init.py
@@ -193,6 +193,8 @@ class ContrailTestInit(fixtures.Fixture):
 #        self.fab_revision = config.get('repos', 'fab_revision')
 
         # debug option
+        self.verify_on_setup = self.read_config_option(
+            'debug', 'verify_on_setup', 'True')
         self.stop_on_fail = False
         stop_on_fail = config.get('debug', 'stop_on_fail')
         if stop_on_fail == "yes":

--- a/scripts/ecmp/ecmp_traffic.py
+++ b/scripts/ecmp/ecmp_traffic.py
@@ -22,13 +22,10 @@ class ECMPTraffic(ConfigSvcChain, VerifySvcChain):
         fab_connections.clear()
         vm_list = [src_vm, dst_vm]
         for vm in vm_list:
-            self.logger.info('Getting the local_ip of the VM')
-            vm.verify_vm_in_agent()
-            out = self.nova_fixture.wait_till_vm_is_active(vm.vm_obj)
+            out = vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:
-                time.sleep(5)
                 self.logger.info('Installing Traffic package on %s ...' %
                                  vm.vm_name)
                 vm.install_pkg("Traffic")
@@ -76,7 +73,6 @@ class ECMPTraffic(ConfigSvcChain, VerifySvcChain):
                 stream=stream, listener=dst_vm.vm_ip, chksum=True)
             sender[stream] = Sender(
                 send_filename, profile[stream], tx_local_host, send_host, self.inputs.logger)
-            time.sleep(5)
             receiver[stream] = Receiver(
                 recv_filename, profile[stream], rx_local_host, recv_host, self.inputs.logger)
             receiver[stream].start()

--- a/scripts/ecmp/sanity.py
+++ b/scripts/ecmp/sanity.py
@@ -1026,7 +1026,7 @@ class TestECMP(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtures)
 
         fvm_list = [fvn_vm2, fvn_vm3]
         for vm in fvm_list:
-            out = self.nova_fixture.wait_till_vm_is_up(vm.vm_obj)
+            out = vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:
@@ -1512,16 +1512,15 @@ class TestECMP(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtures)
         assert vm2.verify_on_setup()
         assert fvn_vm1.verify_on_setup()
 
-        out1 = self.nova_fixture.wait_till_vm_is_up(vm1.vm_obj)
+        out1 = vm1.wait_till_vm_is_up()
         if out1 == False:
             return {'result': out1, 'msg': "%s failed to come up" % vm1.vm_name}
         else:
-            sleep(10)
             self.logger.info('Installing Traffic package on %s ...' %
                              vm1.vm_name)
             vm1.install_pkg("Traffic")
 
-        out2 = self.nova_fixture.wait_till_vm_is_up(vm2.vm_obj)
+        out2 = vm2.wait_till_vm_is_up()
         if out2 == False:
             return {'result': out2, 'msg': "%s failed to come up" % vm2.vm_name}
         else:
@@ -1531,7 +1530,7 @@ class TestECMP(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtures)
                              vm2.vm_name)
             vm2.install_pkg("Traffic")
 
-        out3 = self.nova_fixture.wait_till_vm_is_up(fvn_vm1.vm_obj)
+        out3 = fvn_vm1.wait_till_vm_is_up()
         if out3 == False:
             return {'result': out3, 'msg': "%s failed to come up" % fvn_vm1.vm_name}
         else:

--- a/scripts/ecmp/sanity_w_svc.py
+++ b/scripts/ecmp/sanity_w_svc.py
@@ -112,7 +112,7 @@ class ECMPSvcMonSanityFixture(testtools.TestCase, VerifySvcFirewall, ECMPTraffic
         for vm in vm_list:
             self.logger.info('Getting the local_ip of the VM')
             vm.verify_vm_in_agent()
-            out = self.nova_fixture.wait_till_vm_is_up(vm.vm_obj)
+            vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:
@@ -396,7 +396,7 @@ class ECMPSvcMonSanityFixture(testtools.TestCase, VerifySvcFirewall, ECMPTraffic
         for vm in vm_list:
             self.logger.info('Getting the local_ip of the VM')
             vm.verify_vm_in_agent()
-            out = self.nova_fixture.wait_till_vm_is_up(vm.vm_obj)
+            vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:
@@ -568,7 +568,7 @@ class ECMPSvcMonSanityFixture(testtools.TestCase, VerifySvcFirewall, ECMPTraffic
         for vm in vm_list:
             self.logger.info('Getting the local_ip of the VM')
             vm.verify_vm_in_agent()
-            out = self.nova_fixture.wait_till_vm_is_up(vm.vm_obj)
+            vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:
@@ -775,7 +775,7 @@ class ECMPSvcMonSanityFixture(testtools.TestCase, VerifySvcFirewall, ECMPTraffic
         for vm in vm_list:
             self.logger.info('Getting the local_ip of the VM')
             vm.verify_vm_in_agent()
-            out = self.nova_fixture.wait_till_vm_is_up(vm.vm_obj)
+            vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:
@@ -1023,7 +1023,7 @@ class ECMPSvcMonSanityFixture(testtools.TestCase, VerifySvcFirewall, ECMPTraffic
                     connections=self.connections, vn_obj=vn_obj.obj, vm_name=vm_name,
                     project_name=self.inputs.project_name, flavor='contrail_flavor_small', image_name='ubuntu-traffic'))
             assert vm_fix.verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fix.vm_obj)
+            vm_fix.wait_till_vm_is_up()
             vm_list.append(vm_fix)
 
         action_list = []
@@ -1129,7 +1129,7 @@ class ECMPSvcMonSanityFixture(testtools.TestCase, VerifySvcFirewall, ECMPTraffic
         for vm in vm_list:
             self.logger.info('Getting the local_ip of the VM')
             vm.verify_vm_in_agent()
-            out = self.nova_fixture.wait_till_vm_is_up(vm.vm_obj)
+            vm.wait_till_vm_is_up()
             if out == False:
                 return {'result': out, 'msg': "%s failed to come up" % vm.vm_name}
             else:

--- a/scripts/evpn/verify.py
+++ b/scripts/evpn/verify.py
@@ -199,8 +199,9 @@ class VerifyEvpnCases():
         assert vn2_fixture.verify_on_setup()
         assert vn1_vm1_fixture.verify_on_setup()
         assert vn1_vm2_fixture.verify_on_setup()
+        assert vn1_vm1_fixture.wait_till_vm_is_up()
+        assert vn1_vm2_fixture.wait_till_vm_is_up()
         for i in range(0, 20):
-            sleep(5)
             vm2_ipv6 = vn1_vm2_fixture.get_vm_ipv6_addr_from_vm()
             if vm2_ipv6 is not None:
                 break
@@ -218,12 +219,9 @@ class VerifyEvpnCases():
         sleep(10)
         self.logger.info(
             'Verifying L2 route and other VM verification after restart')
-        assert vn1_vm1_fixture.verify_on_setup()
-        assert vn1_vm2_fixture.verify_on_setup()
-        # vm1_ipv6=vn1_vm1_fixture.get_vm_ipv6_addr_from_vm()
-        # vm2_ipv6=vn1_vm2_fixture.get_vm_ipv6_addr_from_vm()
+        assert vn1_vm1_fixture.verify_on_setup(force=True)
+        assert vn1_vm2_fixture.verify_on_setup(force=True)
         for i in range(0, 20):
-            sleep(5)
             vm2_ipv6 = vn1_vm2_fixture.get_vm_ipv6_addr_from_vm()
             if vm2_ipv6 is not None:
                 break
@@ -293,8 +291,8 @@ class VerifyEvpnCases():
         assert vn_l2_vm2_fixture.verify_on_setup()
 
         # Wait till vm is up
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn_l2_vm2_fixture.vm_obj)
+        vn_l2_vm1_fixture.wait_till_vm_is_up()
+        vn_l2_vm2_fixture.wait_till_vm_is_up()
 
         # Configured IPV6 address
         cmd_to_pass1 = ['ifconfig eth1 inet6 add %s' % (vn1_vm1)]

--- a/scripts/floating_ip_tests.py
+++ b/scripts/floating_ip_tests.py
@@ -482,8 +482,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         assert vn1_fixture.verify_on_setup()
         assert fvn1_vm1_traffic_fixture.verify_on_setup()
         assert vn1_vm1_traffic_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(fvn1_vm1_traffic_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_traffic_fixture.vm_obj)
+        fvn1_vm1_traffic_fixture.wait_till_vm_is_up()
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
 
         # Install traffic pkg in VM
         vn1_vm1_traffic_fixture.install_pkg("Traffic")
@@ -661,8 +661,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         if not vn1_vm1_traffic_fixture.ping_with_certainty(fvn1_vm1_traffic_fixture.vm_ip):
             result = result and False
 
-        self.nova_fixture.wait_till_vm_is_up(fvn1_vm1_traffic_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_traffic_fixture.vm_obj)
+        fvn1_vm1_traffic_fixture.wait_till_vm_is_up()
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
         # Install traffic pkg in VM
         vn1_vm1_traffic_fixture.install_pkg("Traffic")
         fvn1_vm1_traffic_fixture.install_pkg("Traffic")
@@ -848,8 +848,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         self.logger.info('Active control node from the Agent %s is %s' %
                          (vn1_vm1_traffic_fixture.vm_node_ip, active_controller))
 
-        self.nova_fixture.wait_till_vm_is_up(fvn1_vm1_traffic_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_traffic_fixture.vm_obj)
+        fvn1_vm1_traffic_fixture.wait_till_vm_is_up()
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
         # Install traffic pkg in VM
         vn1_vm1_traffic_fixture.install_pkg("Traffic")
         fvn1_vm1_traffic_fixture.install_pkg("Traffic")
@@ -1076,8 +1076,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         assert vn1_fixture.verify_on_setup()
         assert fvn1_vm1_fixture.verify_on_setup()
         assert vn1_vm1_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(fvn1_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_fixture.vm_obj)
+        fvn1_vm1_traffic_fixture.wait_till_vm_is_up()
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
 
         fip_fixture1 = self.useFixture(
             FloatingIPFixture(
@@ -1096,7 +1096,7 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         self.logger.info('Rebooting the VM  %s' % (vn1_vm1_name))
         cmd_to_reboot_vm = ['reboot']
         vn1_vm1_fixture.run_cmd_on_vm(cmds=cmd_to_reboot_vm)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_fixture.vm_obj)
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
         assert vn1_vm1_fixture.verify_on_setup()
         self.logger.info('Verify the connectivity to other VN via floating IP')
         if not vn1_vm1_fixture.ping_with_certainty(fvn1_vm1_fixture.vm_ip):
@@ -1128,8 +1128,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         assert vn1_fixture.verify_on_setup()
         assert fvn1_vm1_fixture.verify_on_setup()
         assert vn1_vm1_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(fvn1_vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_fixture.vm_obj)
+        fvn1_vm1_traffic_fixture.wait_till_vm_is_up()
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
 
         fip_fixture1 = self.useFixture(
             FloatingIPFixture(
@@ -1522,8 +1522,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
                       vn_obj=vn2_fixture.obj, vm_name=vm_names[1], project_name=projects[1], node_name=compute_2))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
 
         # Floating Ip Fixture
         fip_fixture = self.useFixture(
@@ -1584,8 +1584,8 @@ class TestFipCases(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFixtu
         assert vn1_fixture.verify_on_setup()
         assert fvn1_vm1_traffic_fixture.verify_on_setup()
         assert vn1_vm1_traffic_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(fvn1_vm1_traffic_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vn1_vm1_traffic_fixture.vm_obj)
+        fvn1_vm1_traffic_fixture.wait_till_vm_is_up()
+        vn1_vm1_traffic_fixture.wait_till_vm_is_up()
 
         # Install traffic pkg in VM
         vn1_vm1_traffic_fixture.install_pkg("Traffic")

--- a/scripts/performance/verify.py
+++ b/scripts/performance/verify.py
@@ -91,8 +91,8 @@ class PerformanceTest(ConfigPerformance, ConfigSvcChain):
 
             assert self.vm1_fixture.verify_on_setup()
             assert self.vm2_fixture.verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-            self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+            self.vm1_fixture.wait_till_vm_is_up()
+            self.vm2_fixture.wait_till_vm_is_up()
         else:
             if getattr(self, 'res', None):
                 self.vm1_fixture = self.res.vn1_vm5_fixture
@@ -114,8 +114,8 @@ class PerformanceTest(ConfigPerformance, ConfigSvcChain):
 
             assert self.vm1_fixture.verify_on_setup()
             assert self.vm2_fixture.verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-            self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+            self.vm1_fixture.wait_till_vm_is_up()
+            self.vm2_fixture.wait_till_vm_is_up()
         results = []
         # set the cpu to highest performance in compute nodes before running
         # the test
@@ -231,9 +231,8 @@ class PerformanceTest(ConfigPerformance, ConfigSvcChain):
 
             assert self.vm1_fixture.verify_on_setup()
             assert self.vm2_fixture.verify_on_setup()
-            result = self.nova_fixture.wait_till_vm_is_up(
-                self.vm1_fixture.vm_obj)
-            self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+            result = self.vm1_fixture.wait_till_vm_is_up()
+            self.vm2_fixture.wait_till_vm_is_up()
         else:
             if getattr(self, 'res', None):
                 self.vm1_fixture = self.res.vn1_vm5_fixture
@@ -255,8 +254,8 @@ class PerformanceTest(ConfigPerformance, ConfigSvcChain):
 
             assert self.vm1_fixture.verify_on_setup()
             assert self.vm2_fixture.verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-            self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+            self.vm1_fixture.wait_till_vm_is_up()
+            self.vm2_fixture.wait_till_vm_is_up()
 
         # set the cpu to highest performance in compute nodes before running
         # the test

--- a/scripts/policyTrafficTests.py
+++ b/scripts/policyTrafficTests.py
@@ -1225,8 +1225,8 @@ class policyTrafficTestFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm2_name, flavor='contrail_flavor_small', image_name='ubuntu-traffic'))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         self.logger.info("Verify ping to vm %s" % (vn1_vm2_name))
         ret = vm1_fixture.ping_with_certainty(
             vm2_fixture.vm_ip, expectation=True)
@@ -1553,8 +1553,8 @@ class policyTrafficTestFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 project_name=self.inputs.project_name, connections=self.connections,
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm2_name))
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         self.logger.info("Verify ping to vm %s" % (vn1_vm2_name))
         ret = vm1_fixture.ping_with_certainty(
             vm2_fixture.vm_ip, expectation=True)

--- a/scripts/securitygroup/sanity_base.py
+++ b/scripts/securitygroup/sanity_base.py
@@ -85,6 +85,7 @@ class SecurityGroupSanityTestsBase(testtools.TestCase, ConfigSecGroup):
             vn_obj=vn.obj, vm_name=vm_name, image_name='ubuntu-traffic', flavor='contrail_flavor_small',
             sg_ids=[secgrp_id]))
         assert vm.verify_on_setup()
+        assert vm.wait_till_vm_is_up()
         result, msg = vm.verify_security_group(secgrp_name)
         assert result, msg
 

--- a/scripts/servicechain/firewall/verify.py
+++ b/scripts/servicechain/firewall/verify.py
@@ -29,8 +29,8 @@ class VerifySvcFirewall(VerifySvcMirror):
         vm2_fixture = self.config_vm(vn2_fixture, vm2_name)
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
 
         si_count = 3
         st_name = "tcp_svc_template"
@@ -237,8 +237,8 @@ class VerifySvcFirewall(VerifySvcMirror):
             self.vm2_fixture = self.config_vm(self.vn2_fixture, self.vm2_name)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -323,8 +323,8 @@ class VerifySvcFirewall(VerifySvcMirror):
             self.vm2_fixture = self.config_vm(self.vn2_fixture, self.vm2_name)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -455,8 +455,8 @@ class VerifySvcFirewall(VerifySvcMirror):
         assert new_left_vm_fix.verify_on_setup()
         assert new_right_vm_fix.verify_on_setup()
         # Wait for VM's to come up
-        self.nova_fixture.wait_till_vm_is_up(new_left_vm_fix.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(new_right_vm_fix.vm_obj)
+        new_left_vm_fix.wait_till_vm_is_up()
+        new_right_vm_fix.wait_till_vm_is_up()
 
         # Add rule to policy to allow traffic from new left_vn to right_vn
         # through SI
@@ -621,8 +621,8 @@ class VerifySvcFirewall(VerifySvcMirror):
         assert new_left_vm_fix.verify_on_setup()
         assert new_right_vm_fix.verify_on_setup()
         # Wait for VM's to come up
-        self.nova_fixture.wait_till_vm_is_up(new_left_vm_fix.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(new_right_vm_fix.vm_obj)
+        new_left_vm_fix.wait_till_vm_is_up()
+        new_right_vm_fix.wait_till_vm_is_up()
 
         # Ping from left VM to right VM
         errmsg = "Ping to right VM ip %s from left VM failed" % new_right_vm_fix.vm_ip
@@ -824,8 +824,8 @@ class VerifySvcFirewall(VerifySvcMirror):
             self.vm2_fixture = self.config_vm(self.vn2_fixture, self.vm2_name)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg

--- a/scripts/servicechain/mirror/verify.py
+++ b/scripts/servicechain/mirror/verify.py
@@ -102,8 +102,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
                 self.vn2_fixture, self.vm2_name, node_name=compute_2)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
         result, msg = self.validate_vn(self.vn2_name)
@@ -237,8 +237,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
                 self.vn2_fixture, self.vm2_name, node_name=compute_2)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -375,8 +375,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
                 self.vn2_fixture, self.vm2_name, node_name=compute_2)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         self.st_fixture, self.si_fixtures = self.config_st_si(self.st_name,
                                                               self.si_prefix, si_count, svc_type='analyzer', left_vn=self.vn1_name)
@@ -547,8 +547,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
         assert new_left_vm_fix.verify_on_setup()
         assert new_right_vm_fix.verify_on_setup()
         # Wait for VM's to come up
-        self.nova_fixture.wait_till_vm_is_up(new_left_vm_fix.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(new_right_vm_fix.vm_obj)
+        new_left_vm_fix.wait_till_vm_is_up()
+        new_right_vm_fix.wait_till_vm_is_up()
 
         # Add rule to policy to allow traffic from new left_vn to right_vn
         # through SI
@@ -743,8 +743,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
                 self.vn2_fixture, self.vm2_name, node_name=compute_2)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -876,8 +876,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
                 self.vn2_fixture, self.vm2_name, node_name=compute_2)
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -1018,8 +1018,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -1168,8 +1168,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg
@@ -1304,8 +1304,8 @@ class VerifySvcMirror(ConfigSvcMirror, VerifySvcChain):
         assert self.vm1_fixture.verify_on_setup()
         assert self.vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(self.vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(self.vm2_fixture.vm_obj)
+        self.vm1_fixture.wait_till_vm_is_up()
+        self.vm2_fixture.wait_till_vm_is_up()
 
         result, msg = self.validate_vn(self.vn1_name)
         assert result, msg

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -81,10 +81,8 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
             VMFixture(
                 project_name=self.inputs.project_name, connections=self.connections,
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
-        assert vm1_fixture.verify_on_setup()
-        assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        assert vm1_fixture.wait_till_vm_is_up()
+        assert vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         assert vm2_fixture.ping_to_ip(vm1_fixture.vm_ip)
         return True
@@ -137,10 +135,10 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm2_fixture.verify_on_setup()
         assert vm3_fixture.verify_on_setup()
         assert vm4_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
+        vm3_fixture.wait_till_vm_is_up()
+        vm4_fixture.wait_till_vm_is_up()
         # Geting the VM ips
         vm1_ip = vm1_fixture.vm_ip
         vm2_ip = vm2_fixture.vm_ip
@@ -203,8 +201,8 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         assert vm2_fixture.ping_to_ip(vm1_fixture.vm_ip)
         # Geting the VM ips
@@ -320,8 +318,9 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
+
         assert not vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         return True
 
@@ -386,8 +385,8 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         self.logger.info("Verify ping to vm %s" % (vn1_vm2_name))
         ret = vm1_fixture.ping_with_certainty(
             vm2_fixture.vm_ip, expectation=True)
@@ -417,8 +416,8 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm4_name))
         assert vm3_fixture.verify_on_setup()
         assert vm4_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        vm3_fixture.wait_till_vm_is_up()
+        vm4_fixture.wait_till_vm_is_up()
         self.logger.info("Verify ping to vm %s" % (vn1_vm4_name))
         ret = vm3_fixture.ping_with_certainty(
             vm4_fixture.vm_ip, expectation=True)
@@ -491,8 +490,8 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         return True
 
@@ -529,6 +528,7 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
 
         try:
             assert vm_fixture.verify_vms_on_setup()
+            assert vm_fixture.wait_till_vms_are_up()
             assert vm_fixture.verify_vns_on_setup()
         except Exception as e:
             self.logger.exception("Got exception as %s" % (e))
@@ -541,6 +541,7 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
         sleep(30)
         try:
             assert vm_fixture.verify_vms_on_setup()
+            assert vm_fixture.wait_till_vms_are_up()
 #            for vmobj in vm_fixture.vm_obj_dict.values():
 #                assert vmobj.verify_on_setup()
         except Exception as e:
@@ -586,8 +587,9 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
+
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         assert vm2_fixture.ping_to_ip(vm1_fixture.vm_ip)
 
@@ -687,8 +689,9 @@ class TestSanityFixture(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
+
         assert vm2_fixture.ping_to_ip(vm1_fixture.vm_ip)
 
         # Collecting all the control node details
@@ -967,7 +970,8 @@ echo "Hello World.  The time is now $(date -R)!" | tee /tmp/output.txt
                                                 flavor='m1.tiny'))
 
         assert vm1_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        
         cmd = 'ls /tmp/'
 
         for i in range(3):
@@ -1129,7 +1133,7 @@ echo "Hello World.  The time is now $(date -R)!" | tee /tmp/output.txt
                                                 image_name='ubuntu-traffic'))
 
         assert vm1_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
 
         metadata_args = "--admin_user admin \
          --admin_password contrail123 --linklocal_service_name generic_link_local\

--- a/scripts/tests_with_setup_base.py
+++ b/scripts/tests_with_setup_base.py
@@ -93,6 +93,7 @@ class TestSanityBase(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFix
         vm1_fixture = self.useFixture(VMFixture(connections=self.connections,
                                                 vn_obj=vn_obj, vm_name=vm1_name, project_name=self.inputs.project_name, image_name='ubuntu'))
         assert vm1_fixture.verify_on_setup()
+        assert vm1_fixture.wait_till_vm_is_up()
         return True
     # end test_vm_add_delete
 
@@ -108,10 +109,13 @@ class TestSanityBase(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFix
         result = True
         fip_pool_name = 'some-pool1'
         fvn_name = self.res.fip_vn_name
-        fvn_fixture = self.res.fvn_fixture
-        vn1_fixture = self.res.vn1_fixture
-        vn1_vm1_fixture = self.res.vn1_vm1_fixture
-        fvn_vm1_fixture = self.res.fvn_vm1_fixture
+        fvn_fixture = self.res.get_fvn_fixture()
+        vn1_fixture = self.res.get_vn1_fixture()
+        vn1_vm1_fixture = self.res.get_vn1_vm1_fixture()
+        assert vn1_vm1_fixture.verify_on_setup(force=True)
+        assert vn1_vm1_fixture.wait_till_vm_is_up()
+        fvn_vm1_fixture = self.res.get_fvn_vm1_fixture()
+        assert fvn_vm1_fixture.wait_till_vm_is_up()
         fvn_subnets = self.res.fip_vn_subnets
         vm1_name = self.res.vn1_vm1_name
         vn1_name = self.res.vn1_name

--- a/scripts/topo_steps.py
+++ b/scripts/topo_steps.py
@@ -283,7 +283,14 @@ def createVMNova(self, option='openstack', vms_on_single_compute=False, VmToNode
         "Setup step: Verify VM status and install Traffic package... ")
     for vm in self.topo.vmc_list:
         if self.skip_verify == 'no':
-            vm_verify_out = self.vm_fixture[vm].verify_on_setup()
+            # Include retry to handle time taken by less powerful computes or
+            # if launching more VMs...
+            retry = 0
+            while True:
+                vm_verify_out = self.vm_fixture[vm].wait_till_vm_is_up()
+                retry += 1
+                if vm_verify_out == True or retry > 2:
+                    break
             if vm_verify_out == False:
                 m = "on compute %s - vm %s verify failed after setup" % (self.vm_fixture[vm].vm_node_ip,
                                                                          self.vm_fixture[vm].vm_name)

--- a/scripts/vdns/vdns_tests.py
+++ b/scripts/vdns/vdns_tests.py
@@ -123,7 +123,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 VMFixture(project_name=self.inputs.project_name, connections=self.connections, vn_obj=vn_quantum_obj, vm_name=vm_name))
             vm_fixture[vm_name].verify_vm_launched()
             vm_fixture[vm_name].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[vm_name].vm_obj)
+            vm_fixture[vm_name].wait_till_vm_is_up()
             vm_ip = vm_fixture[vm_name].get_vm_ip_from_vm(
                 vn_fq_name=vm_fixture[vm_name].vn_fq_name)
             vm_rev_ip = vm_ip.split('.')
@@ -234,7 +234,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 VMFixture(project_name=self.inputs.project_name, connections=self.connections, vn_obj=vn_quantum_obj, vm_name=vm_name))
             vm_fixture[vm_name].verify_vm_launched()
             vm_fixture[vm_name].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[vm_name].vm_obj)
+            vm_fixture[vm_name].wait_till_vm_is_up()
             msg = "Ping by using name %s is failed. Dns server should resolve VM name to IP" % (
                 vm_name)
             self.assertTrue(vm_fixture[vm_name]
@@ -444,7 +444,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 VMFixture(project_name=self.inputs.project_name, connections=self.connections, vn_obj=vn_quantum_obj, vm_name=vm_name))
             vm_fixture[vm_name].verify_vm_launched()
             vm_fixture[vm_name].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[vm_name].vm_obj)
+            vm_fixture[vm_name].wait_till_vm_is_up()
 
         # Verify DNS entries are resolved for sub domains.
         for vm_name in vm_list:
@@ -560,7 +560,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 VMFixture(project_name=self.inputs.project_name, connections=self.connections, vn_obj=vn_quantum_obj, vm_name=vm_name))
             vm_fixture[vm_name].verify_vm_launched()
             vm_fixture[vm_name].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[vm_name].vm_obj)
+            vm_fixture[vm_name].wait_till_vm_is_up()
             vm_ip = vm_fixture[vm_name].get_vm_ip_from_vm(
                 vn_fq_name=vm_fixture[vm_name].vn_fq_name)
             vm_rev_ip = vm_ip.split('.')
@@ -733,7 +733,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                       connections=self.connections, vn_obj=vn_quantum_obj, vm_name='vm1-test'))
         vm_fixture.verify_vm_launched()
         vm_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm_fixture.vm_obj)
+        vm_fixture.wait_till_vm_is_up()
 
         rec_ip_list = []
         i = 1
@@ -900,7 +900,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 VMFixture(project_name=self.inputs.project_name, connections=self.connections, vn_obj=vn_fixt[vm_name].obj, vm_name=vm_name))
             vm_fixture[vm_name].verify_vm_launched()
             vm_fixture[vm_name].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[vm_name].vm_obj)
+            vm_fixture[vm_name].wait_till_vm_is_up()
 
         # FIP
         fip_fixture1 = self.useFixture(
@@ -993,7 +993,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                     vm_name=vm_list[proj]))
             vm_fix[proj].verify_vm_launched()
             vm_fix[proj].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fix[proj].vm_obj)
+            vm_fixture[vm_name].wait_till_vm_is_up()
             msg = "Ping by using name %s is failed. Dns server should resolve VM name to IP" % (
                 vm_list[proj])
             self.assertTrue(
@@ -1056,7 +1056,7 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 vm_name=vm_name))
         vm_fix.verify_vm_launched()
         vm_fix.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm_fix.vm_obj)
+        vm_fix.wait_till_vm_is_up()
         # FIP creation
         fip_fixture = self.useFixture(
             FloatingIPFixture(
@@ -1230,7 +1230,8 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                 project_name=self.inputs.project_name, connections=self.connections, vn_obj=vn_fixt[dns_name].obj, vm_name=vm_dns_list[dns_name]))
             vm_fixture[dns_name].verify_vm_launched()
             vm_fixture[dns_name].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[dns_name].vm_obj)
+            vm_fixture[dns_name].wait_till_vm_is_up()
+            vm_ip_dns_list[dns_name] = vm_fixture[dns_name].vm_ip
         # perform NS lookup for each level
         import re
         for dns in dns_server_name_list:
@@ -1332,7 +1333,9 @@ class TestVdnsFixture(testtools.TestCase, VdnsFixture):
                     vn_obj=vn_fixt.obj, vm_name=vm_name))
             vm_fixture[vdns].verify_vm_launched()
             vm_fixture[vdns].verify_on_setup()
-            self.nova_fixture.wait_till_vm_is_up(vm_fixture[vdns].vm_obj)
+            vm_fixture[vdns].wait_till_vm_is_up()
+            # get vm IP from nova
+            vm_ip = vm_fixture[vdns].vm_ip
             i = i + 1
             cmd = 'nslookup ' + vm_name
             self.logger.info(

--- a/scripts/vm_vn_tests.py
+++ b/scripts/vm_vn_tests.py
@@ -178,8 +178,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
 
         return True
@@ -208,8 +208,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         self.logger.info('Will restart the services now')
         for compute_ip in self.inputs.compute_ips:
@@ -274,8 +274,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
 
         try:
@@ -359,8 +359,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                                                 vn_obj=vn_obj, vm_name=vm2_name, project_name=self.inputs.project_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
 
         self.logger.info(
@@ -395,7 +395,7 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         vm1_fixture = self.useFixture(VMFixture(connections=self.connections,
                                                 vn_obj=vn_obj, vm_name=vm1_name, project_name=self.inputs.project_name))
         assert vm1_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
 
         self.logger.info('Adding the same address as a Static IP')
         cmd = 'ifconfig eth0 %s netmask 255.255.255.0' % vm1_fixture.vm_ip
@@ -464,15 +464,17 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vn_fixture.verify_on_setup()
         vn_obj = vn_fixture.obj
         vm1_fixture = self.useFixture(VMFixture(connections=self.connections,
-                                                vn_obj=vn_obj, flavor='contrail_flavor_small', image_name='ubuntu-traffic', vm_name=vm1_name, project_name=self.inputs.project_name))
-        assert vm1_fixture.verify_on_setup()
+                            vn_obj=vn_obj, flavor='contrail_flavor_small', 
+                            image_name='ubuntu-traffic', vm_name=vm1_name, 
+                            project_name=self.inputs.project_name))
         vm2_fixture = self.useFixture(VMFixture(connections=self.connections,
-                                                vn_obj=vn_obj, flavor='contrail_flavor_small', image_name='ubuntu-traffic', vm_name=vm2_name, project_name=self.inputs.project_name))
-        assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+                            vn_obj=vn_obj, flavor='contrail_flavor_small', 
+                            image_name='ubuntu-traffic', vm_name=vm2_name, 
+                            project_name=self.inputs.project_name))
+        assert vm1_fixture.wait_till_vm_is_up()
+        assert vm2_fixture.wait_till_vm_is_up()
+
         # ssh and tftp taking sometime to be up and runnning
-        sleep(60)
         for size in file_sizes:
             self.logger.info("-" * 80)
             self.logger.info("FILE SIZE = %sB" % size)
@@ -495,7 +497,11 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                 self.logger.error(
                     'File of size %sB not transferred via tftp ' % size)
 
-        assert transfer_result, 'File not transferred via tftp '
+        if not transfer_result:
+            self.logger.error('Tftp transfer failed, lets verify basic things')
+            assert vm1_fixture.verify_on_setup()
+            assert vm2_fixture.verify_on_setup()
+            assert transfer_result
         return transfer_result
     # end test_vm_file_trf_tftp_tests
 
@@ -675,7 +681,7 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         vm1_fixture = self.useFixture(VMFixture(connections=self.connections,
                                                 vn_obj=vn_obj, vm_name=vm1_name, project_name=self.inputs.project_name, flavor='contrail_flavor_small', image_name='ubuntu-traffic'))
         assert vm1_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
         route_cmd = 'route -n'
         vm1_fixture.run_cmd_on_vm(cmds=[route_cmd], as_sudo=True)
         output = vm1_fixture.return_output_cmd_dict[route_cmd]
@@ -695,7 +701,7 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         vm2_fixture = self.useFixture(VMFixture(connections=self.connections,
                                                 vn_obj=vn_obj, vm_name=vm2_name, project_name=self.inputs.project_name, flavor='contrail_flavor_small', image_name='ubuntu-traffic'))
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm2_fixture.wait_till_vm_is_up()
         new_route_cmd = 'route -n'
         vm2_fixture.run_cmd_on_vm(cmds=[new_route_cmd], as_sudo=True)
         new_output = vm2_fixture.return_output_cmd_dict[new_route_cmd]
@@ -762,15 +768,11 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
 
         vm5_fixture = self.useFixture(VMFixture(connections=self.connections,
                                                 vn_obj=vn_obj, vm_name='vm_xlarge', flavor='m1.xlarge', project_name=self.inputs.project_name))
-        assert vm1_fixture.verify_on_setup()
-        assert vm2_fixture.verify_on_setup()
-        assert vm3_fixture.verify_on_setup()
-        assert vm4_fixture.verify_on_setup()
-        assert vm5_fixture.verify_on_setup()
 
         for a in range(1, 6):
-            eval('self.nova_fixture.wait_till_vm_is_up(vm%d_fixture.vm_obj )' %
+            wait = eval('vm%d_fixture.wait_till_vm_is_up()' %
                  a)
+            assert 'wait'
 
         for i in range(1, 5):
             for j in range(i + 1, 6):
@@ -897,7 +899,7 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
             'vm2 has not booted up as expected.Starting vrouter service')
         for compute_ip in self.inputs.compute_ips:
             self.inputs.start_service('contrail-vrouter', [compute_ip])
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm2_fixture.wait_till_vm_is_up()
         self.logger.info('vm2 is up now as expected')
         assert vm2_fixture.verify_on_setup()
 
@@ -1076,20 +1078,18 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
             assert vm1_fixture.verify_on_setup()
             assert vm2_fixture.verify_on_setup()
 
-        out1 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out1 = vm1_fixture.wait_till_vm_is_up()
         if out1 == False:
             return {'result': out1, 'msg': "%s failed to come up" % vm1_fixture.vm_name}
         else:
-            sleep(10)
             self.logger.info('Will install Traffic package on %s' %
                              vm1_fixture.vm_name)
             vm1_fixture.install_pkg("Traffic")
 
-        out2 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out2 = vm2_fixture.wait_till_vm_is_up()
         if out2 == False:
             return {'result': out2, 'msg': "%s failed to come up" % vm2_fixture.vm_name}
         else:
-            sleep(10)
             self.logger.info('Will install Traffic package on %s' %
                              vm2_fixture.vm_name)
             vm2_fixture.install_pkg("Traffic")
@@ -1201,20 +1201,18 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
             assert vm1_fixture.verify_on_setup()
             assert vm2_fixture.verify_on_setup()
 
-        out1 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out1 = vm1_fixture.wait_till_vm_is_up()
         if out1 == False:
             return {'result': out1, 'msg': "%s failed to come up" % vm1_fixture.vm_name}
         else:
-            sleep(10)
             self.logger.info('Will install Traffic package on %s' %
                              vm1_fixture.vm_name)
             vm1_fixture.install_pkg("Traffic")
 
-        out2 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out2 = vm2_fixture.wait_till_vm_is_up()
         if out2 == False:
             return {'result': out2, 'msg': "%s failed to come up" % vm2_fixture.vm_name}
         else:
-            sleep(10)
             self.logger.info('Will install Traffic package on %s' %
                              vm2_fixture.vm_name)
             vm2_fixture.install_pkg("Traffic")
@@ -1339,7 +1337,7 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
             assert vm1_fixture.verify_on_setup()
             assert vm2_fixture.verify_on_setup()
 
-        out1 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out1 = vm1_fixture.wait_till_vm_is_up()
         if out1 == False:
             return {'result': out1, 'msg': "%s failed to come up" % vm1_fixture.vm_name}
         else:
@@ -1348,7 +1346,7 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                              vm1_fixture.vm_name)
             vm1_fixture.install_pkg("Traffic")
 
-        out2 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out2 = vm2_fixture.wait_till_vm_is_up()
         if out2 == False:
             return {'result': out2, 'msg': "%s failed to come up" % vm2_fixture.vm_name}
         else:
@@ -1516,8 +1514,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
 
         self.logger.info(
@@ -1554,8 +1552,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm3_fixture.verify_on_setup()
         assert vm4_fixture.verify_on_setup()
 
-        self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        vm3_fixture.wait_till_vm_is_up()
+        vm4_fixture.wait_till_vm_is_up()
         assert not vm4_fixture.ping_to_ip(vm3_fixture.vm_ip)
         return True
     # end test_policy_between_vns_diff_proj
@@ -1926,19 +1924,16 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, flavor='contrail_flavor_small', image_name='ubuntu-traffic', vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
 
-        out1 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out1 = vm1_fixture.wait_till_vm_is_up()
         if out1 == False:
             return {'result': out1, 'msg': "%s failed to come up" % vm1_fixture.vm_name}
         else:
-            sleep(10)
             self.logger.info('Will install Traffic package on %s' %
                              vm1_fixture.vm_name)
             vm1_fixture.install_pkg("Traffic")
 
-        out2 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out2 = vm2_fixture.wait_till_vm_is_up()
         if out2 == False:
             return {'result': out2, 'msg': "%s failed to come up" % vm2_fixture.vm_name}
         else:
@@ -2009,8 +2004,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         assert vm2_fixture.ping_to_ip(vm1_fixture.vm_ip)
         return True
@@ -2053,10 +2048,11 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm2_fixture.verify_on_setup()
         assert vm3_fixture.verify_on_setup()
         assert vm4_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
+        vm3_fixture.wait_till_vm_is_up()
+        vm4_fixture.wait_till_vm_is_up()
+
         # Geting the VM ips
         vm1_ip = vm1_fixture.vm_ip
         vm2_ip = vm2_fixture.vm_ip
@@ -2151,42 +2147,34 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         #self.nova_fixture.wait_till_vm_is_up( vm3_fixture.vm_obj )
         #self.nova_fixture.wait_till_vm_is_up( vm4_fixture.vm_obj )
 
-        out1 = self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
+        out1 = vm1_fixture.wait_till_vm_is_up()
         if out1 == False:
             return {'result': out1, 'msg': "%s failed to come up" % vm1_fixture.vm_name}
         else:
-            sleep(
-                10)
             self.logger.info('Installing Traffic package on %s ...' %
                              vm1_fixture.vm_name)
             vm1_fixture.install_pkg("Traffic")
 
-        out2 = self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        out2 = vm2_fixture.wait_till_vm_is_up()
         if out2 == False:
             return {'result': out2, 'msg': "%s failed to come up" % vm2_fixture.vm_name}
         else:
-            sleep(
-                10)
             self.logger.info('Installing Traffic package on %s ...' %
                              vm2_fixture.vm_name)
             vm2_fixture.install_pkg("Traffic")
 
-        out3 = self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
+        out3 = vm3_fixture.wait_till_vm_is_up()
         if out3 == False:
             return {'result': out3, 'msg': "%s failed to come up" % vm3_fixture.vm_name}
         else:
-            sleep(
-                10)
             self.logger.info('Installing Traffic package on %s ...' %
                              vm3_fixture.vm_name)
             vm3_fixture.install_pkg("Traffic")
 
-        out4 = self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        out4 = vm4_fixture.wait_till_vm_is_up()
         if out4 == False:
             return {'result': out4, 'msg': "%s failed to come up" % vm4_fixture.vm_name}
         else:
-            sleep(
-                10)
             self.logger.info('Installing Traffic package on %s ...' %
                              vm4_fixture.vm_name)
             vm4_fixture.install_pkg("Traffic")
@@ -2317,10 +2305,10 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
         assert vm2_fixture.verify_on_setup()
         assert vm3_fixture.verify_on_setup()
         assert vm4_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
+        vm3_fixture.wait_till_vm_is_up()
+        vm4_fixture.wait_till_vm_is_up()
         # Geting the VM ips
         vm1_ip = vm1_fixture.vm_ip
         vm2_ip = vm2_fixture.vm_ip
@@ -2380,8 +2368,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn1_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         assert vm1_fixture.ping_to_ip(vm2_fixture.vm_ip)
         assert vm2_fixture.ping_to_ip(vm1_fixture.vm_ip)
         # Geting the VM ips
@@ -2476,8 +2464,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm2_name))
         assert vm1_fixture.verify_on_setup()
         assert vm2_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm1_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm2_fixture.vm_obj)
+        vm1_fixture.wait_till_vm_is_up()
+        vm2_fixture.wait_till_vm_is_up()
         self.logger.info("Verify ping to vm %s" % (vn1_vm2_name))
         ret = vm1_fixture.ping_with_certainty(
             vm2_fixture.vm_ip, expectation=True)
@@ -2507,8 +2495,8 @@ class TestVMVN(testtools.TestCase, fixtures.TestWithFixtures):
                 vn_obj=vn2_fixture.obj, vm_name=vn1_vm4_name))
         assert vm3_fixture.verify_on_setup()
         assert vm4_fixture.verify_on_setup()
-        self.nova_fixture.wait_till_vm_is_up(vm3_fixture.vm_obj)
-        self.nova_fixture.wait_till_vm_is_up(vm4_fixture.vm_obj)
+        vm3_fixture.wait_till_vm_is_up()
+        vm4_fixture.wait_till_vm_is_up()
         self.logger.info("Verify ping to vm %s" % (vn1_vm4_name))
         ret = vm3_fixture.ping_with_certainty(
             vm4_fixture.vm_ip, expectation=True)

--- a/scripts/vpc/sanity.py
+++ b/scripts/vpc/sanity.py
@@ -365,10 +365,14 @@ class VPCSanityTests(testtools.TestCase, ResourcedTestCase, fixtures.TestWithFix
             vm_name='fip_vm1'))
         assert fip_vm_fixture.verify_on_setup(
         ), "VM verification in FIP VN failed"
+        assert fip_vm_fixture.wait_till_vm_is_up(),\
+            "VM verification in FIP VN failed"
 
         vm1_fixture = self.res.vpc1_vn1_vm1_fixture
         assert vm1_fixture.verify_on_setup(), "VPCVMFixture verification failed " \
             "for VM %s" % (vm1_fixture.instance_id)
+        assert vm1_fixture.wait_till_vm_is_up(),\
+            "VM verification failed"
 
         fip_fixture = self.useFixture(VPCFIPFixture(
             fip_vn_fixture=fip_vn_fixture,


### PR DESCRIPTION
...e based verify_on_setup() calls can be skipped altogether. Caller can still force a verify based on argument. Modified Sanity tests to use vmfixture.wait_till_vm_is_up
