### PR TITLE
1.	Removing activate venv in contrail-test/scripts/scale/control-node/pa...

### DIFF
--- a/fixtures/webui_test.py
+++ b/fixtures/webui_test.py
@@ -633,8 +633,9 @@ class WebuiTest:
                     if item['process_name'] == 'contrail-collector':
                         contrail_collector_string = self.webui_common.get_process_status_string(
                             item, process_down_stop_time_dict, process_up_start_time_dict)
-                reduced_process_keys_dict = {
-                    k: v for k, v in process_down_stop_time_dict.items() if k not in exclude_process_list}
+		for k, v in process_down_stop_time_dict.items():
+			if k not in exclude_process_list:
+				reduced_process_keys_dict[k]=v
                 if not reduced_process_keys_dict:
                     for process in exclude_process_list:
                         process_up_start_time_dict.pop(process, None)
@@ -733,8 +734,9 @@ class WebuiTest:
                     if item['process_name'] == 'contrail-svc-monitor':
                         monitor_string = self.webui_common.get_process_status_string(
                             item, process_down_stop_time_dict, process_up_start_time_dict)
-                reduced_process_keys_dict = {
-                    k: v for k, v in process_down_stop_time_dict.items() if k not in exclude_process_list}
+		for k, v in process_down_stop_time_dict.items():
+			if k not in exclude_process_list:
+				reduced_process_keys_dict[k]=v
                 if not reduced_process_keys_dict:
                     for process in exclude_process_list:
                         process_up_start_time_dict.pop(process, None)
@@ -926,8 +928,9 @@ class WebuiTest:
                     if item['process_name'] == 'openstack-nova-compute':
                         openstack_nova_compute_string = self.webui_common.get_process_status_string(
                             item, process_down_stop_time_dict, process_up_start_time_dict)
-                reduced_process_keys_dict = {
-                    k: v for k, v in process_down_stop_time_dict.items() if k not in exclude_process_list}
+		for k, v in process_down_stop_time_dict.items():
+			if k not in exclude_process_list:
+				reduced_process_keys_dict[k] = v
                 '''
                 if not reduced_process_keys_dict :
                     recent_time = max(process_up_start_time_dict.values())
@@ -1217,8 +1220,10 @@ class WebuiTest:
                     if item['process_name'] == 'contrail-named':
                         contrail_named_string = self.webui_common.get_process_status_string(
                             item, process_down_stop_time_dict, process_up_start_time_dict)
-                reduced_process_keys_dict = {
-                    k: v for k, v in process_down_stop_time_dict.items() if k not in exclude_process_list}
+		for k, v in process_down_stop_time_dict.items():
+                        if k not in exclude_process_list:
+                                reduced_process_keys_dict[k] = v
+
                 if not reduced_process_keys_dict:
                     for process in exclude_process_list:
                         process_up_start_time_dict.pop(process, None)

--- a/scripts/contrail_test_init.py
+++ b/scripts/contrail_test_init.py
@@ -21,6 +21,24 @@ from fabric.context_managers import settings, hide
 from util import *
 from custom_filehandler import *
 
+import subprocess
+
+#monkey patch subprocess.check_output cos its not supported in 2.6
+if "check_output" not in dir( subprocess ): # duck punch it in!
+    def f(*popenargs, **kwargs):
+        if 'stdout' in kwargs:
+            raise ValueError('stdout argument not allowed, it will be overridden.')
+        process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
+        output, unused_err = process.communicate()
+        retcode = process.poll()
+        if retcode:
+            cmd = kwargs.get("args")
+            if cmd is None:
+                cmd = popenargs[0]
+            raise subprocess.CalledProcessError(retcode, cmd)
+        return output
+    subprocess.check_output = f
+
 # sys.path.append(os.path.realpath("/root/test/scripts/"))
 # sys.path.append(os.path.realpath("/root/test/fixtures/"))
 

--- a/scripts/scale/control-node/params.ini
+++ b/scripts/scale/control-node/params.ini
@@ -26,7 +26,7 @@ reboot_cmd=shutdown -r now
 run_cpu_test=0
 run_cpu_test=0
 bgp_test_script=flap_agent_scale_test.py
-start_bgp_test_cmd=source /opt/contrail/api-venv/bin/activate; export PYTHONPATH=/root/test/fixtures/:/root/test/scripts/:/usr/lib/python2.6/site-packages;ulimit -n 16384;ulimit -c unlimited;ulimit -s unlimited;ulimit -d unlimited;ulimit -v unlimited;screen -d -m python flap_agent_scale_test.py -c params.ini --multiple_testservers_running 1
+start_bgp_test_cmd= export PYTHONPATH=/root/test/fixtures/:/root/test/scripts/:/usr/lib/python2.6/site-packages;ulimit -n 16384;ulimit -c unlimited;ulimit -s unlimited;ulimit -d unlimited;ulimit -v unlimited;screen -d -m python flap_agent_scale_test.py -c params.ini --multiple_testservers_running 1
 
 [Control_node]
 control_node_ips=10.84.7.41, 10.84.7.42


### PR DESCRIPTION
...rams.ini
1.  Dynamic dict removal in contrail-test/fixtures/webui_test.py
2.  Subprocess.check_output not available in python 2.6 so monkey patched from http://stackoverflow.com/questions/4814970/subprocess-check-output-doesnt-seem-to-exist-python-2-6-5
   In contrail-test/scripts/contrail_test_init.py
