### PR TITLE
Fix project_create call to vnc api

### DIFF
--- a/fixtures/contrailapi.py
+++ b/fixtures/contrailapi.py
@@ -28,7 +28,8 @@ class ContrailVncApi(object):
         return self._vnc.network_policy_read(fq_name=fq_name)
 
     def create_project(self, project_name):
-        return self._vnc.project_create(project_name)
+        project = Project(project_name)
+        return self._vnc.project_create(project)
 
     def delete_project(self, project_name):
         return self._vnc.project_delete(project_name)


### PR DESCRIPTION
Using function `project_create` on vnc_api with string name causes  `_StringException`. Valid way of creating new project via vnc_api requires creating Project object first, as in the example from documentation [virtual network example](http://www.opencontrail.org/documentation/api/r3.2/tutorial_with_library.html). 

Traceback from test run which requires creation of new project
```
_StringException: Traceback (most recent call last):
File "scripts/k8s_scripts/test_fabric_forwarding.py", line 10, in setUpClass
super(TestFabricFWD, cls).setUpClass()
File "common/k8s/base.py", line 52, in setUpClass
api_option='contrail')
File "tcutils/util.py", line 925, in __call__
Singleton, cls).__call__(*args, **kwargs)
File "common/create_public_vn.py", line 39, in __init__
self.setUp()
File "common/create_public_vn.py", line 62, in setUp
self.project.setUp()
File "/contrail-test/fixtures/project_test.py", line 99, in setUp
self.create()
File "/contrail-test/fixtures/project_test.py", line 133, in create
self._create_project()
File "/contrail-test/fixtures/project_test.py", line 74, in _create_project
self.project_name)
File "/contrail-test/fixtures/vnc_api_test.py", line 236, in hook
return act_attr(*args, **kwargs)
File "/contrail-test/fixtures/contrailapi.py", line 31, in create_project
return self._vnc.project_create(project_name)
File "/usr/lib/python2.7/site-packages/vnc_api/vnc_api.py", line 57, in wrapper
return func(self, *args, **kwargs)
File "/usr/lib/python2.7/site-packages/vnc_api/vnc_api.py", line 622, in _object_create
obj._pending_field_updates |= obj._pending_ref_updates
AttributeError: 'str' object has no attribute '_pending_field_updates'
```